### PR TITLE
Nicer error messages, Selectable C/Z/T

### DIFF
--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -80,7 +80,9 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     # Create an individual OMERO.table for this image
     #print fids
     #print features
-    answer = pyslid.features.link(conn, imageId, scale, fids, features, ftset)
+    answer = pyslid.features.link(
+        conn, imageId, scale, fids, features, ftset, field=True, rid=None,
+        pixels=0, channel=channels[0], zslice=zslice, timepoint=timepoint)
 
     if answer:
         message += 'Extracted features from Image id:%d\n' % imageId

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -91,9 +91,10 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
 
     # Create the global contentDB
     # TODO: Implement this per-dataset level (already supported by PySLID)
-    # TODO: Set server and usernames
+    # TODO: Set servername, change update parameter from username to userid
     server = 'NA'
-    username = 'NA'
+    # Username can change, UserId should be constant
+    username = image.getOwner().getId()
     answer, m = pyslid.database.direct.update(
         conn, server, username, scale,
         imageId, pixels, channels[0], zslice, timepoint, fids, features, ftset)

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -14,8 +14,10 @@ pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 # 0 or 1 based indexing in the UI?
 IDX_OFFSET = 0
 
-def extractFeatures(conn, image, scale, ftset, scaleSet,
-                    channels, zselect, tselect):
+
+
+def extractFeaturesOneChannel(conn, image, scale, ftset, scaleSet,
+                              channels, zslice, timepoint):
     """
     Calculate features for one image, link to the image, save to the ContentDB.
     @param scaleSet a read write parameter, calculated scales should be
@@ -23,50 +25,8 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     the end.
     """
     message = ''
-
     imageId = image.getId()
-
-    # TODO: should be configurable (or process all c/z/t)
-    # TODO: provide user option to only calculate if not already present
-    # (pyslid.feature.has)
     pixels = 0
-    if channels[0] < IDX_OFFSET or channels[0] >= image.getSizeC() + IDX_OFFSET:
-        m = 'Channel %d not found in Image id:%d' % (channels[0], imageId)
-        sys.stderr.write(m)
-        return message + m
-    if ftset == 'slf33':
-        channels = (channels[0] - IDX_OFFSET,)
-    if ftset == 'slf34':
-        if (channels[1] < IDX_OFFSET or
-            channels[1] >= image.getSizeC() + IDX_OFFSET):
-            m = 'Channel %d not found in Image id:%d' % (channels[1], imageId)
-            sys.stderr.write(m)
-            return message + m + '\n'
-        channels = (channels[0] - IDX_OFFSET, channels[1] - IDX_OFFSET)
-
-    if zselect[0] == 'Middle':
-        zslice = image.getSizeZ() / 2
-    elif zselect[0] == 'Select Index':
-        if (zselect[1] < IDX_OFFSET or
-            zselect[1] >= image.getSizeZ() + IDX_OFFSET):
-            m = 'Z-slice %d not found in Image id:%d' % (zselect[1], imageId)
-            sys.stderr.write(m)
-            return message + m + '\n'
-        zslice = zselect[1] - IDX_OFFSET
-    else:
-        raise Exception('Unexpected zselect')
-
-    if tselect[0] == 'Middle':
-        timepoint = image.getSizeT() / 2
-    elif tselect[0] == 'Select Index':
-        if (tselect[1] < IDX_OFFSET or
-            tselect[1] >= image.getSizeT() + IDX_OFFSET):
-            m = 'Timepoint %d not found in Image id:%d' % (tselect[1], imageId)
-            sys.stderr.write(m)
-            return message + m + '\n'
-        timepoint = tselect[1] - IDX_OFFSET
-    else:
-        raise Exception('Unexpected tselect')
 
     message += 'Calculating features ftset:%s scale:%e c:%s z:%d t:%d\n' % (
         ftset, scale, channels, zslice, timepoint)
@@ -105,6 +65,67 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
         message, imageID, m)
 
 
+def extractFeatures(conn, image, scale, ftset, scaleSet,
+                    channels, zselect, tselect):
+    """
+    Extract features for the requested channel(s)
+    """
+
+    message = ''
+    imageId = image.getId()
+
+    # TODO: provide user option to only calculate if not already present
+
+    if zselect[0]:
+        zslice = image.getSizeZ() / 2
+    else:
+        if (zselect[1] < IDX_OFFSET or
+            zselect[1] >= image.getSizeZ() + IDX_OFFSET):
+            m = 'Z-slice %d not found in Image id:%d' % (zselect[1], imageId)
+            sys.stderr.write(m)
+            return message + m + '\n'
+        zslice = zselect[1] - IDX_OFFSET
+
+    if tselect[0]:
+        timepoint = image.getSizeT() / 2
+    else:
+        if (tselect[1] < IDX_OFFSET or
+            tselect[1] >= image.getSizeT() + IDX_OFFSET):
+            m = 'Timepoint %d not found in Image id:%d' % (tselect[1], imageId)
+            sys.stderr.write(m)
+            return message + m + '\n'
+        timepoint = tselect[1] - IDX_OFFSET
+
+    allChannels = channels[0]
+
+    if allChannels:
+        readoutCh = range(image.getSizeC())
+    else:
+        if (channels[1] < IDX_OFFSET or
+            channels[1] >= image.getSizeC() + IDX_OFFSET):
+            m = 'Channel %d not found in Image id:%d' % (channels[1], imageId)
+            sys.stderr.write(m)
+            return message + m
+        readoutCh = [channels[1] - IDX_OFFSET]
+
+    if ftset == 'slf33':
+        otherChs = []
+    if ftset == 'slf34':
+        if (channels[2] < IDX_OFFSET or
+            channels[2] >= image.getSizeC() + IDX_OFFSET):
+            m = 'Channel %d not found in Image id:%d' % (channels[2], imageId)
+            sys.stderr.write(m)
+            return message + m + '\n'
+        otherChs = [channels[2] - IDX_OFFSET]
+
+    for c in readoutCh:
+        chs = [c] + otherChs
+        message += extractFeaturesOneChannel(
+            conn, image, scale, ftset, scaleSet, chs, zslice, timepoint)
+
+    return message
+
+
 def processImages(client, scriptParams):
     message = ''
 
@@ -114,11 +135,12 @@ def processImages(client, scriptParams):
     ftset = scriptParams['Feature_set']
     scale = float(scriptParams['Scale'])
 
-    channels = (scriptParams['Readout_Channel'],
-                scriptParams['Reference_Channel'])
+    channels = (scriptParams['Readout_All_Channels'],
+                scriptParams['Select_Readout_Channel'],
+                scriptParams['Select_Reference_Channel'])
 
-    zselect = (scriptParams['Z_Index'], scriptParams['Select_Z'])
-    tselect = (scriptParams['Timepoint'], scriptParams['Select_T'])
+    zselect = (scriptParams['Use_Middle_Z'], scriptParams['Select_Z'])
+    tselect = (scriptParams['Use_Middle_T'], scriptParams['Select_T'])
 
     try:
         nimages = 0
@@ -201,45 +223,45 @@ def runScript():
                        values=[rstring('slf33'), rstring('slf34')],
                        default='slf33'),
 
+        scripts.Bool('Readout_All_Channels', optional=False, grouping='3',
+                     description='Which readout channel(s) to use',
+                     default=True),
+
         scripts.Long(
-            'Readout_Channel', optional=False, grouping='2',
-            description=('slf33/slf34 readout channel, starting from %d' %
+            'Select_Readout_Channel', optional=False, grouping='3.1',
+            description=('slf33/slf34 readout channel (starting from %d)' %
                          IDX_OFFSET),
             default=IDX_OFFSET),
 
         scripts.Long(
-            'Reference_Channel', optional=False, grouping='2',
+            'Select_Reference_Channel', optional=False, grouping='4',
             description=('slf34 reference channel (ignored for slf33), starting from %d' %
                          IDX_OFFSET),
             default=IDX_OFFSET + 1),
 
 
-        scripts.String('Z_Index', optional=False, grouping='3',
+        scripts.Bool('Use_Middle_Z', optional=False, grouping='5',
                        description='Which Z-slice to use',
-                       values=[rstring('Middle'), rstring('Select Index')],
-                       default='Middle'),
+                       default=True),
 
         scripts.Long(
-            'Select_Z', optional=False, grouping='3',
-            description=('Select Z index if not middle (starting from %d)' %
-                         IDX_OFFSET),
+            'Select_Z', optional=False, grouping='5.1',
+            description='Select Z index (starting from %d)' % IDX_OFFSET,
             default=-1),
 
 
-        scripts.String('Timepoint', optional=False, grouping='4',
-                       description='Which timepoint to use',
-                       values=[rstring('Middle'), rstring('Select Index')],
-                       default='Middle'),
+        scripts.Bool('Use_Middle_T', optional=False, grouping='6',
+                     description='Which timepoint to use',
+                     default=True),
 
         scripts.Long(
-            'Select_T', optional=False, grouping='4',
-            description=('Select timepoint if not middle (starting from %d)' %
-                         IDX_OFFSET),
+            'Select_T', optional=False, grouping='6.1',
+            description='Select timepoint (starting from %d)' % IDX_OFFSET,
             default=-1),
 
 
         scripts.String(
-            'Scale', optional=False, grouping='5',
+            'Scale', optional=False, grouping='7',
             description='Scale',
             default=rstring('1.0')),
 

--- a/templates/searcher/contentsearch/search_error.html
+++ b/templates/searcher/contentsearch/search_error.html
@@ -6,7 +6,7 @@
 
         <!-- from search_details.html -->
     <div>
-      No features were found for the reference images. Please use the Omero Searcher Feature Calculation script to calculate them before running a search.
+      {{ message }}
     </div>
 
 {% endblock %}

--- a/templates/searcher/contentsearch/search_no_input_features.html
+++ b/templates/searcher/contentsearch/search_no_input_features.html
@@ -1,0 +1,12 @@
+{% extends "webclient/search/search_details.html" %}
+{% load i18n %}
+{% load common_filters %}
+
+{% block search_results %}
+
+        <!-- from search_details.html -->
+    <div>
+      No features were found for the reference images. Please use the Omero Searcher Feature Calculation script to calculate them before running a search.
+    </div>
+
+{% endblock %}

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -162,7 +162,7 @@
                             <!-- hidden input for form submission -->
                             <input name="posNeg-{{ c.id }}" style="display:none"
                                 value="{% if c.posNeg %}pos{% else %}neg{% endif %}" />
-                            {% if c.posNeg %}+{% else %}-{% endif %}
+                            {% if not c.hasFeats %}No features{% else %}{% if c.posNeg %}+{% else %}-{% endif %}{% endif %}
                         </td> 
                     </tr>
                 {% endfor %}

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -149,18 +149,17 @@
                     <tr>
                         <td class="action">
                             <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
-                            <input name="allIds" style="display:none" value="{{c.id}}" type="text" />
+                            <input name="superIds" style="display:none" value="{{c.superid}}" type="text" />
 
                         </td>
                         <td style="display:none"></td>
                         <td>
-                            <input style="display:none" type="text" name="czt-{{ c.id }}" value="{{ c.czt }}" size="3"></input>
                             <span id="czt-{{ c.id }}">{{ c.czt }}</span>
                         </td>
                         <td>{{ c.name }}</td>
                         <td align="center">
                             <!-- hidden input for form submission -->
-                            <input name="posNeg-{{ c.id }}" style="display:none"
+                            <input name="posNeg-{{ c.superid }}" style="display:none"
                                 value="{% if c.posNeg %}pos{% else %}neg{% endif %}" />
                             {% if not c.hasFeats %}No features{% else %}{% if c.posNeg %}+{% else %}-{% endif %}{% endif %}
                         </td> 

--- a/templates/searcher/contentsearch/searchresult.html
+++ b/templates/searcher/contentsearch/searchresult.html
@@ -21,13 +21,7 @@
             </thead>
             <tbody>
                 {% for c in images %}
-                    <tr id="image-{{ c.id }}" class="{{ c.getPermsCss }}">
-		    {% comment %}
-		    TODO: This works with the Acquisition and Preview right
-		    hand tabs but not the General tab:
                     <tr id="image-{{ c.id }}-{{ c.superid }}" class="{{ c.getPermsCss }}">
-		    For now just put up with duplicate DOM IDs errors
-		    {% endcomment %}
                         <td class="action">
                             <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
                             <input name="superIds" style="display:none" value="{{ c.superid }}" type="text" />

--- a/templates/searcher/contentsearch/searchresult.html
+++ b/templates/searcher/contentsearch/searchresult.html
@@ -22,9 +22,15 @@
             <tbody>
                 {% for c in images %}
                     <tr id="image-{{ c.id }}" class="{{ c.getPermsCss }}">
+		    {% comment %}
+		    TODO: This works with the Acquisition and Preview right
+		    hand tabs but not the General tab:
+                    <tr id="image-{{ c.id }}-{{ c.superid }}" class="{{ c.getPermsCss }}">
+		    For now just put up with duplicate DOM IDs errors
+		    {% endcomment %}
                         <td class="action">
                             <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
-                            <input name="allIds" style="display:none" value="{{c.id}}" type="text" />
+                            <input name="superIds" style="display:none" value="{{ c.superid }}" type="text" />
 
                         </td>
                         <td class="ranking">{{ c.ranki }}</td>
@@ -36,12 +42,12 @@
                         </td>
                         <td>{{ c.name }}</td>
                         <td align="center">
-                            <input type="radio" name="posNeg-{{ c.id }}" value="neg">
+                            <input type="radio" name="posNeg-{{ c.superid }}" value="neg">
                             <!-- 'type' span shown when we move row to left panel -->
                             <span class="posNegType" style="display:none">+</span>
                         </td> 
                         <td align="center">
-                            <input type="radio" name="posNeg-{{ c.id }}" value="pos">
+                            <input type="radio" name="posNeg-{{ c.superid }}" value="pos">
                         </td> 
                     </tr>
                 {% endfor %}

--- a/templates/searcher/plugin_config/right_search_form.js.html
+++ b/templates/searcher/plugin_config/right_search_form.js.html
@@ -7,7 +7,16 @@ $(document).ready(function() {
         load_tab_content: function(selected, obj_dtype, obj_id) {    // This MUST be defined
             var imageIds = [];
             for (var i=0; i<selected.length; i++) {
-                imageIds.push(selected[i]["id"].replace("-","="));
+		// IDs will be in the form image-<id> if coming from the
+		// standard middle pane, or image-<id>-<superid> if coming
+		// from the OMERO.searcher middle pane
+		sid = selected[i]["id"].split('-');
+		if (sid.length > 2) {
+		    imageIds.push(sid[0] + 'superid=' +  sid[2]);
+		}
+		else {
+		    imageIds.push(sid.join('='));
+		}
             }
             queryString = imageIds.join("&");
             $(this).load('{% url right_plugin_search_form %}?' + queryString);

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -155,24 +155,24 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                         </td>
                         <td>
                             <div style="position:relative">
-                                {% with defZ=c.getDefaultZ defT=c.getDefaultT %}
-                                <input style="display:none" type="text" name="czt-{{ c.id }}" value="0.0.0" size="3"></input>
+                                {# with defZ=c.getDefaultZ defT=c.getDefaultT #}
+                                {% with defZ=c.defZ defT=c.defT %}
                                 <span class="cztEdit" title="Edit Channel/Z/T">0.{{ defZ }}.{{ defT }}</span>
                                 <div class="cztSelects" style="display:none">
-                                    <select title="Choose C index">
-                                        {% for i in c.getSizeC|get_range %}
+                                    <select name="selected_c-{{ c.id }}" title="Choose C index">
+                                        {% for i in c.im.getSizeC|get_range %}
                                             <option value="{{ i }}">{{ i }}</option>
                                         {% endfor %}
                                     </select>
-                                    <select title="Choose Z index">
-                                        {% for i in c.getSizeZ|get_range %}
+                                    <select name="selected_z-{{ c.id }}" title="Choose Z index">
+                                        {% for i in c.im.getSizeZ|get_range %}
                                             <option value="{{ i }}" {% ifequal i defZ %}selected='true'{% endifequal %}>
                                                 {{ i }}
                                             </option>
                                         {% endfor %}
                                     </select>
-                                    <select title="Choose T index">
-                                        {% for i in c.getSizeT|get_range %}
+                                    <select name="selected_t-{{ c.id }}" title="Choose T index">
+                                        {% for i in c.im.getSizeT|get_range %}
                                             <option value="{{ i }}" {% ifequal i defT %}selected='true'{% endifequal %}>
                                                 {{ i }}
                                             </option>
@@ -182,7 +182,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                                 {% endwith %}
                             </div>
                         </td>
-                        <td>{{ c.name }}</td>
+                        <td>{{ c.im.name }}</td>
                         <td align="center">
                             <input type="radio" name="posNeg-{{ c.id }}" value="neg">
                         </td> 

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -150,28 +150,30 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                     <tr>
                         <td class="action">
                             <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
-                            <input name="allIds" style="display:none" value="{{c.id}}" type="text" />
+                            <input name="allIds" style="display:none" value="{{c.superid}}" type="text" />
 
                         </td>
                         <td>
                             <div style="position:relative">
                                 {# with defZ=c.getDefaultZ defT=c.getDefaultT #}
-                                {% with defZ=c.defZ defT=c.defT %}
-                                <span class="cztEdit" title="Edit Channel/Z/T">0.{{ defZ }}.{{ defT }}</span>
+                                {% with defC=c.defC defZ=c.defZ defT=c.defT %}
+                                <span class="cztEdit" title="Edit Channel/Z/T">{{ defC }}.{{ defZ }}.{{ defT }}</span>
                                 <div class="cztSelects" style="display:none">
-                                    <select name="selected_c-{{ c.id }}" title="Choose C index">
+                                    <select name="selected_c-{{ c.superid }}" title="Choose C index">
                                         {% for i in c.im.getSizeC|get_range %}
-                                            <option value="{{ i }}">{{ i }}</option>
+                                            <option value="{{ i }}" {% ifequal i defC %}selected='true'{% endifequal %}>
+                                                {{ i }}
+                                            </option>
                                         {% endfor %}
                                     </select>
-                                    <select name="selected_z-{{ c.id }}" title="Choose Z index">
+                                    <select name="selected_z-{{ c.superid }}" title="Choose Z index">
                                         {% for i in c.im.getSizeZ|get_range %}
                                             <option value="{{ i }}" {% ifequal i defZ %}selected='true'{% endifequal %}>
                                                 {{ i }}
                                             </option>
                                         {% endfor %}
                                     </select>
-                                    <select name="selected_t-{{ c.id }}" title="Choose T index">
+                                    <select name="selected_t-{{ c.superid }}" title="Choose T index">
                                         {% for i in c.im.getSizeT|get_range %}
                                             <option value="{{ i }}" {% ifequal i defT %}selected='true'{% endifequal %}>
                                                 {{ i }}
@@ -184,10 +186,10 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                         </td>
                         <td>{{ c.im.name }}</td>
                         <td align="center">
-                            <input type="radio" name="posNeg-{{ c.id }}" value="neg">
+                            <input type="radio" name="posNeg-{{ c.superid }}" value="neg">
                         </td> 
                         <td align="center">
-                            <input type="radio" name="posNeg-{{ c.id }}" value="pos" checked="true">
+                            <input type="radio" name="posNeg-{{ c.superid }}" value="pos" checked="true">
                         </td> 
                     </tr>
                 {% endfor %}

--- a/views.py
+++ b/views.py
@@ -154,7 +154,14 @@ def contentsearch( request, conn=None, **kwargs):
     logger.debug('contentsearch image_refs_dict:%s', image_refs_dict)
 
     cdb, s = pyslid.database.direct.retrieve(conn, ftset)
-    assert(s == 'Good')
+
+    if s != 'Good':
+        context = {'template':
+                       'searcher/contentsearch/search_error.html'}
+        context['message'] = (
+            'The ContentDB for feature-set %s could not be found.'
+            'Have you calculated any features?') % ftset
+        return context
 
     def processIds(cdbr):
         return ['.'.join(str(c) for c in cdbr[6:11]), cdbr[2], cdbr[1]]
@@ -186,7 +193,12 @@ def contentsearch( request, conn=None, **kwargs):
     logger.debug('contentsearch cdb.keys():%s', cdb.keys())
     if len(image_refs_dict) == 0:
         # No images had features
-        context = {'template': 'searcher/contentsearch/search_no_input_features.html'}
+        context = {'template':
+                       'searcher/contentsearch/search_error.html'}
+        context['message'] = (
+            'No features were found for the reference images. Please use the '
+            'Omero Searcher Feature Calculation script to calculate them '
+            'before running a search.')
         return context
 
     try:


### PR DESCRIPTION
Testing: Don't merge this yet, I'll setup ome-analysis-01 at some point.
- If you select an image without features you should get an error message instead of an exception.
- The feature calculation script allows C/Z/T to be chosen, defaults are all channels middle Z middle T.
- In the right hand pane clicking on the C.Z.T triplet for a reference image should make them editable. In practice you'll probably only want to change the channel unless you've specifically requested features for other Z/T.
- Multiple results for the same image (different C/Z/T) should be supported. This requires changing DOM IDs from object-id to object-id-extrastuff, and therefore requires PR https://github.com/openmicroscopy/openmicroscopy/pull/1234 to avoid breaking OMERO.web.
- The feature calculation script now has the option to not recalculate features if they are already present, default don't recalculate.
