### PR TITLE
Added script for rebuilding OMERO.searcher ContentDB from tables

### DIFF
--- a/scripts/Omero_Searcher_Delete_Feature_Tables.py
+++ b/scripts/Omero_Searcher_Delete_Feature_Tables.py
@@ -1,0 +1,177 @@
+import omero
+from omero import scripts
+from omero.util import script_utils
+from omero.rtypes import rstring, rlong
+from datetime import datetime
+import itertools
+import sys
+
+import pyslid
+from omeroweb.omero_searcher.omero_searcher_config import omero_contentdb_path
+pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
+
+
+
+def deleteImageFeatures(conn, cli, image, ftset, field=True):
+    """
+    Delete any OMERO.searcher feature tables attached to an image
+    """
+    message = ''
+    iid = image.getId()
+
+    query = ('select iml from ImageAnnotationLink as iml join '
+             'fetch iml.child as fileAnn join '
+             'fetch fileAnn.file join '
+             'iml.parent as img where '
+             'img.id = :iid and fileAnn.file.name = :filename')
+
+    if field:
+       filename = 'iid-' + str(iid) + '_feature-' + ftset + '_field.h5';
+    else:
+       filename = 'iid-' + str(iid) + '_feature-' + ftset + '_roi.h5';
+    params = omero.sys.ParametersI()
+    params.addLong('iid', iid);
+    params.addString('filename', filename);
+
+    qs = conn.getQueryService()
+    imAnns = qs.findAllByQuery(query, params)
+
+    if not imAnns:
+        return message
+
+    ds = conn.getDeleteService();
+    dcs = []
+    for imAnn in imAnns:
+        fileAnn = imAnn.getChild()
+        dcs.append(omero.api.delete.DeleteCommand(
+                "/Annotation", fileAnn.id.val, None))
+
+    delHandle = ds.queueDelete(dcs)
+    cb = omero.callbacks.DeleteCallbackI(cli, delHandle)
+
+    try:
+        try:
+            cb.loop(10 * len(dcs), 500)
+        except omero.LockTimeout:
+            m = 'Not finished in %d seconds. Cancelling...' % (len(dcs) * 5)
+            sys.stderr.write(m)
+            message += m
+            if not delHandle.cancel():
+                m = 'ERROR: Failed to cancel\n'
+                sys.stderr.write(m)
+                message += m
+
+        reports = delHandle.report()
+        for r in reports:
+            m = 'Delete report: error:%s warning:%s, deleted:%s\n' % (
+                r.error, r.warning, r.actualDeletes)
+            message  += m
+
+    finally:
+        #cb.close()
+        pass
+
+    return message
+
+
+def processImages(client, scriptParams):
+    message = ''
+
+    dataType = scriptParams['Data_Type']
+    ids = scriptParams['IDs']
+    ftset = scriptParams['Feature_set']
+
+    try:
+        conn = omero.gateway.BlitzGateway(client_obj=client)
+
+        # Get the objects
+        objects, logMessage = script_utils.getObjects(conn, scriptParams)
+        message += logMessage
+
+        if not objects:
+            return message
+
+        if dataType == 'Image':
+            for image in objects:
+                message += 'Processing image id:%d\n' % image.getId()
+                m = deleteImageFeatures(conn, client, image, ftset, field=True)
+                message += m
+
+        else:
+            if dataType == 'Project':
+                datasets = [proj.listChildren() for proj in objects]
+                datasets = itertools.chain.from_iterable(datasets)
+            else:
+                datasets = objects
+
+            for d in datasets:
+                message += 'Processing dataset id:%d\n' % d.getId()
+                for image in d.listChildren():
+                    message += 'Processing image id:%d\n' % image.getId()
+                    m = deleteImageFeatures(
+                        conn, client, image, ftset, field=True)
+                    message += m
+
+    except:
+        print message
+        raise
+
+    return message
+
+def runScript():
+    """
+    The main entry point of the script, as called by the client via the scripting service, passing the required parameters.
+    """
+
+    client = scripts.client(
+        'OMERO.searcher delete individual image feature tables',
+        'Delete the image feature tables belonging to each image. '
+        'Note this does not delete the entries from the ContentDB',
+
+        scripts.String('Data_Type', optional=False, grouping='1',
+                       description='The data you want to work with.',
+                       values=[rstring('Project'), rstring('Dataset'), rstring('Image')],
+                       default='Dataset'),
+
+        scripts.List(
+            'IDs', optional=False, grouping='1',
+            description='List of Dataset, Project or Image IDs').ofType(rlong(0)),
+
+        scripts.String('Feature_set', optional=False, grouping='1',
+                       description='SLF set',
+                       values=[rstring('slf33'), rstring('slf34')],
+                       default='slf33'),
+
+        version = '0.0.1',
+        authors = ['Marvin the Paranoid Android'],
+        institutions = ['Heart of Gold'],
+        contact = 'spli@dundee.ac.uk',
+    )
+
+    try:
+        startTime = datetime.now()
+        session = client.getSession()
+        client.enableKeepAlive(60)
+        scriptParams = {}
+
+        # process the list of args above.
+        for key in client.getInputKeys():
+            if client.getInput(key):
+                scriptParams[key] = client.getInput(key, unwrap=True)
+        message = str(scriptParams) + '\n'
+
+        # Run the script
+        message += processImages(client, scriptParams) + '\n'
+
+        stopTime = datetime.now()
+        message += 'Duration: %s' % str(stopTime - startTime)
+
+        print message
+        client.setOutput('Message', rstring(message))
+
+    finally:
+        client.closeSession()
+
+if __name__ == '__main__':
+    runScript()
+

--- a/scripts/Omero_Searcher_Rebuild_ContentDB.py
+++ b/scripts/Omero_Searcher_Rebuild_ContentDB.py
@@ -1,0 +1,203 @@
+import omero
+from omero import scripts
+from omero.rtypes import rstring
+from datetime import datetime
+import sys
+
+import pyslid
+from omeroweb.omero_searcher.omero_searcher_config import omero_contentdb_path
+pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
+
+
+class CdbArgs:
+
+    class Cdb1:
+        def __init__(self, uid, scale):
+            self.server = 'NA'
+            self.uid = uid
+            self.scale = scale
+            self.iid = []
+            self.px = []
+            self.c = []
+            self.z = []
+            self.t = []
+            self.feats = []
+
+    def __init__(self):
+        self.dbs = {}
+        self.fid = None
+
+    def get(self, uid, scale):
+        k = (uid, scale)
+        if k not in self.dbs:
+            self.dbs[k] = self.Cdb1(uid, scale)
+        return self.dbs[k]
+
+    def add(self, uid, scale, fid, iid, px, c, z, t, feats):
+        if not self.fid:
+            self.fid = fid
+        if self.fid != fid:
+            raise Exception('Feature IDs for %d.%d.%d.%d.%d %e does not match existing IDs' %
+                            (iid, px, c, z, t, scale))
+
+        cdb = self.get(uid, scale)
+        cdb.iid.append(iid)
+        cdb.px.append(px)
+        cdb.c.append(c)
+        cdb.z.append(z)
+        cdb.t.append(t)
+        cdb.feats.append(feats)
+
+
+
+def imageFeatures(conn, image, ftset, cdbs):
+    """
+    Read in features from a HDF5 table attached to an image, save to the
+    ContentDB.
+    """
+    message = ''
+    iid = image.getId()
+
+    try:
+        tab = pyslid.features.get(conn, 'vector', iid, set=ftset)
+    except pyslid.utilities.PyslidException as e:
+        m = 'No features found for image:%d\n' % iid
+        sys.stderr.write(m)
+        return m
+
+    uid = image.getOwner().getId()
+    fid = tab[0][5:]
+    featsWithMeta = tab[1]
+    n = len(featsWithMeta)
+
+    # Iterate in reverse order, so that in case of duplicates the most
+    # recent is kept
+    featsWithMeta.reverse()
+    uniq = set()
+
+    for f in featsWithMeta:
+        iden = f[:5]
+        if iden in uniq:
+            continue
+        else:
+            uniq.add(iden)
+
+        px, c, z, t, scale = f[:5]
+        feats = f[5:]
+        cdbs.add(uid, scale, fid, iid, px, c, z, t, feats)
+
+    sys.stdout.write(
+        'Found %d feature rows including %d duplicates for image:%d\n' % (
+            n, n - len(uniq), iid))
+    return message
+
+
+def saveToCdb(conn, ftset, cdbs):
+    message = ''
+
+    # Delete the old ContentDB
+    r = pyslid.database.direct.deleteTableLink(conn, ftset, did=None)
+    if not r:
+        m = 'ERROR: Failed to delete old ContentDB\n'
+        sys.stderr.write(m)
+        message += m
+
+    # Create the new global ContentDB
+    for k in cdbs.dbs:
+        m = 'Saving ContentDB user:%d scale:%e\n' % k
+        sys.stdout.write(m)
+        message += m
+
+        cdb = cdbs.dbs[k]
+        answer, m = pyslid.database.direct.updateDataset(
+            conn, cdb.server, cdb.uid, cdb.scale,
+            cdb.iid, cdb.px, cdb.c, cdb.z, cdb.t,
+            cdbs.fid, cdb.feats, ftset, did=None)
+        message += m + '\n'
+
+        superids = ''.join('\t%d.%d.%d.%d.%d\n' % s for s in
+                           zip(*(cdb.iid, cdb.px, cdb.c, cdb.z, cdb.t)))
+
+    if answer:
+        sys.stdout.write('Added ContentDB features (scale:%e) from:\n%s' % (
+                cdb.scale, superids))
+    else:
+        m = 'Failed to add ContentDB features (user:%d scale:%e) from:\n%s' % (
+            cdb.uid, cdb.scale, superids)
+        sys.stderr.write(m)
+        message += m
+
+    return message
+
+
+def processImages(client, scriptParams):
+    message = ''
+
+    ftset = scriptParams['Feature_set']
+
+    try:
+        conn = omero.gateway.BlitzGateway(client_obj=client)
+
+        cdbs = CdbArgs()
+
+        # Get all images
+        ims = conn.getObjects('Image', None)
+        for im in ims:
+            m = imageFeatures(conn, im, ftset, cdbs)
+            message += m
+
+        m = saveToCdb(conn, ftset, cdbs)
+        message += m
+    except:
+        print message
+        raise
+
+    return message
+
+def runScript():
+    """
+    The main entry point of the script, as called by the client via the scripting service, passing the required parameters.
+    """
+
+    client = scripts.client(
+        'OMERO.searcher rebuild ContentDB',
+        'Delete the ContentDB and rebuild from image feature tables',
+
+        scripts.String('Feature_set', optional=False, grouping='1',
+                       description='SLF set',
+                       values=[rstring('slf33'), rstring('slf34')],
+                       default='slf33'),
+
+        version = '0.0.1',
+        authors = ['Marvin the Paranoid Android'],
+        institutions = ['Heart of Gold'],
+        contact = 'spli@dundee.ac.uk',
+    )
+
+    try:
+        startTime = datetime.now()
+        session = client.getSession()
+        client.enableKeepAlive(60)
+        scriptParams = {}
+
+        # process the list of args above.
+        for key in client.getInputKeys():
+            if client.getInput(key):
+                scriptParams[key] = client.getInput(key, unwrap=True)
+        message = str(scriptParams) + '\n'
+
+        # Run the script
+        message += processImages(client, scriptParams) + '\n'
+
+        stopTime = datetime.now()
+        message += 'Duration: %s' % str(stopTime - startTime)
+
+        print message
+        client.setOutput('Message', rstring(message))
+
+    finally:
+        client.closeSession()
+
+if __name__ == '__main__':
+    runScript()
+


### PR DESCRIPTION
Run this script to delete the ContentDB and rebuild it using the per-image HDF5 feature tables. See Trac [#11010](https://trac.openmicroscopy.org.uk/ome/ticket/11010)

Also added a script to delete individual image tables.
