### PR TITLE
PR3 PR4 and feature calculation script improvements

### DIFF
--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -46,9 +46,14 @@ def extractFeaturesOneChannel(conn, image, scale, ftset, scaleSet,
     mid = 'image:%d c:%s z:%d t:%d' % (imageId, channels, zslice, timepoint)
 
     print 'Calculating features ftset:%s scale:%e %s' % (ftset, scale, mid)
-    [fids, features, scalec] = pyslid.features.calculate(
-        conn, imageId, scale, ftset, True, None,
-        pixels, channels, zslice, timepoint, debug=True)
+    try:
+        [fids, features, scalec] = pyslid.features.calculate(
+            conn, imageId, scale, ftset, True, None,
+            pixels, channels, zslice, timepoint, debug=True)
+    except pyslid.utilities.PyslidException as e:
+        m = 'Feature calculation failed for %s\nException:%s\n' % (mid, e)
+        sys.stderr.write(m)
+        return message + m
 
     if features is None:
         m = 'Feature calculation failed for %s\n' % mid

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -195,7 +195,7 @@ def processImages(client, scriptParams):
         scale = float(scriptParams['Scale'])
         disableCdb = scriptParams['Disable_ContentDB_Update']
     else:
-        recalc = True
+        recalc = False
         scale = 1.0
         disableCdb = False
 

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -308,7 +308,7 @@ def runScript():
         scripts.Long(
             'Select_Z', optional=False, grouping='5.1',
             description='Select Z index (starting from %d)' % IDX_OFFSET,
-            default=-1),
+            default=0),
 
 
         scripts.Bool(
@@ -319,7 +319,7 @@ def runScript():
         scripts.Long(
             'Select_T', optional=False, grouping='6.1',
             description='Select timepoint (starting from %d)' % IDX_OFFSET,
-            default=-1),
+            default=0),
 
 
         scripts.Bool(

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -43,14 +43,17 @@ def extractFeaturesOneChannel(conn, image, scale, ftset, scaleSet,
     imageId = image.getId()
     pixels = 0
 
-    message += 'Calculating features ftset:%s scale:%e c:%s z:%d t:%d\n' % (
-        ftset, scale, channels, zslice, timepoint)
+    mid = 'image:%d c:%s z:%d t:%d' % (imageId, channels, zslice, timepoint)
+
+    print 'Calculating features ftset:%s scale:%e %s' % (ftset, scale, mid)
     [fids, features, scalec] = pyslid.features.calculate(
         conn, imageId, scale, ftset, True, None,
         pixels, channels, zslice, timepoint, debug=True)
 
     if features is None:
-      return message + 'Failed Image id:%d\n' % imageId
+        m = 'Feature calculation failed for %s\n' % mid
+        sys.stderr.write(m)
+        return message + m
 
     # Create an individual OMERO.table for this image
     #print fids
@@ -60,12 +63,15 @@ def extractFeaturesOneChannel(conn, image, scale, ftset, scaleSet,
         pixels=0, channel=channels[0], zslice=zslice, timepoint=timepoint)
 
     if answer:
-        message += 'Extracted features from Image id:%d\n' % imageId
+        print 'Extracted features from %s' % mid
     else:
-       return message + 'Failed to link features to Image id:%d\n' % imageId
+        m = 'Failed to link features to %s\n' % mid
+        sys.stderr.write(m)
+        return message + m
 
     if disableCdb:
-        return message + 'ContentDB update disabled\n'
+        print 'ContentDB update disabled'
+        return message
 
     # Create the global contentDB
     # TODO: Implement this per-dataset level (already supported by PySLID)
@@ -73,14 +79,22 @@ def extractFeaturesOneChannel(conn, image, scale, ftset, scaleSet,
     server = 'NA'
     # Username can change, UserId should be constant
     username = image.getOwner().getId()
-    answer, m = pyslid.database.direct.update(
-        conn, server, username, scale,
-        imageId, pixels, channels[0], zslice, timepoint, fids, features, ftset)
-    if answer:
-        scaleSet.add(scale)
-        return message
-    return '%sFailed to update ContentDB with Image id:%d (%s)\n' (
-        message, imageID, m)
+    try:
+        answer, um = pyslid.database.direct.update(
+            conn, server, username, scale,
+            imageId, pixels, channels[0], zslice, timepoint,
+            fids, features, ftset)
+        if answer:
+            scaleSet.add(scale)
+            return message
+
+    except omero.SecurityViolation as e:
+        # Ignore e.serverStackTrace in client message
+        um = '%s %s' % (e.serverExceptionClass, e.message)
+
+    m = 'Failed to update ContentDB with %s : %s\n' % (mid, um)
+    sys.stderr.write(m)
+    return message + m
 
 
 def extractFeatures(conn, image, scale, ftset, scaleSet,
@@ -102,9 +116,9 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     else:
         if (zselect[1] < IDX_OFFSET or
             zselect[1] >= image.getSizeZ() + IDX_OFFSET):
-            m = 'Z-slice %d not found in Image id:%d' % (zselect[1], imageId)
+            m = 'Z-slice %d not found in Image id:%d\n' % (zselect[1], imageId)
             sys.stderr.write(m)
-            return message + m + '\n'
+            return message + m
         zslice = zselect[1] - IDX_OFFSET
 
     if tselect[0]:
@@ -112,9 +126,10 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     else:
         if (tselect[1] < IDX_OFFSET or
             tselect[1] >= image.getSizeT() + IDX_OFFSET):
-            m = 'Timepoint %d not found in Image id:%d' % (tselect[1], imageId)
+            m = 'Timepoint %d not found in Image id:%d\n' % (
+                tselect[1], imageId)
             sys.stderr.write(m)
-            return message + m + '\n'
+            return message + m
         timepoint = tselect[1] - IDX_OFFSET
 
     allChannels = channels[0]
@@ -124,7 +139,7 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     else:
         if (channels[1] < IDX_OFFSET or
             channels[1] >= image.getSizeC() + IDX_OFFSET):
-            m = 'Channel %d not found in Image id:%d' % (channels[1], imageId)
+            m = 'Channel %d not found in Image id:%d\n' % (channels[1], imageId)
             sys.stderr.write(m)
             return message + m
         readoutCh = [channels[1] - IDX_OFFSET]
@@ -134,16 +149,16 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     if ftset == 'slf34':
         if (channels[2] < IDX_OFFSET or
             channels[2] >= image.getSizeC() + IDX_OFFSET):
-            m = 'Channel %d not found in Image id:%d' % (channels[2], imageId)
+            m = 'Channel %d not found in Image id:%d\n' % (channels[2], imageId)
             sys.stderr.write(m)
-            return message + m + '\n'
+            return message + m
         otherChs = [channels[2] - IDX_OFFSET]
 
     for c in readoutCh:
         chs = [c] + otherChs
 
         if (c, zslice, timepoint, scale) in existing:
-            message += 'Features already present for %d %d.%d.%d %e\n' % (
+            print 'Features already present for %d %d.%d.%d (%e)' % (
                 imageId, c, zslice, timepoint, scale)
         else:
             message += extractFeaturesOneChannel(
@@ -185,9 +200,10 @@ def processImages(client, scriptParams):
 
         # Get the objects
         objects, logMessage = script_utils.getObjects(conn, scriptParams)
-        message += logMessage
+        print logMessage
 
         if not objects:
+            message += logMessage
             return message
 
         # TODO: Consider wrapping each image calculation with a trry-catch
@@ -195,7 +211,7 @@ def processImages(client, scriptParams):
 
         if dataType == 'Image':
             for image in objects:
-                message += 'Processing image id:%d\n' % image.getId()
+                print 'Processing image id:%d' % image.getId()
                 msg = extractFeatures(
                     conn, image, scale, ftset, scaleSet,
                     channels, zselect, tselect, recalc, disableCdb)
@@ -209,9 +225,9 @@ def processImages(client, scriptParams):
                 datasets = objects
 
             for d in datasets:
-                message += 'Processing dataset id:%d\n' % d.getId()
+                print 'Processing dataset id:%d' % d.getId()
                 for image in d.listChildren():
-                    message += 'Processing image id:%d\n' % image.getId()
+                    print 'Processing image id:%d' % image.getId()
                     msg = extractFeatures(
                         conn, image, scale, ftset, scaleSet,
                         channels, zselect, tselect, recalc, disableCdb)
@@ -219,12 +235,14 @@ def processImages(client, scriptParams):
 
         # Finally tidy up by removing duplicates
         for s in scaleSet:
-            message += 'Removing duplicates from scale:%g\n' % s
+            print 'Removing duplicates from scale:%g' % s
             a, msg = pyslid.database.direct.removeDuplicates(
                 conn, s, ftset, did=None)
+            print msg
             if not a:
-                message += 'Failed: '
-            message += msg + '\n'
+                m = 'Failed to remove duplicates scale:%g\n %s' % (s, msg)
+                sys.stderr.write(m)
+                message += m
 
 
     except:
@@ -327,6 +345,8 @@ def runScript():
         contact = 'icaoberg@cmu.edu',
     )
 
+    message = ''
+
     try:
         startTime = datetime.now()
         session = client.getSession()
@@ -337,15 +357,15 @@ def runScript():
         for key in client.getInputKeys():
             if client.getInput(key):
                 scriptParams[key] = client.getInput(key, unwrap=True)
-        message = str(scriptParams) + '\n'
+        print '%s' % scriptParams
 
         # Run the script
         message += processImages(client, scriptParams) + '\n'
+        print '\nMessage:\n%s\n' % message
 
         stopTime = datetime.now()
-        message += 'Duration: %s' % str(stopTime - startTime)
+        print 'Duration: %s' % (stopTime - startTime)
 
-        print message
         client.setOutput('Message', rstring(message))
 
     finally:

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -137,7 +137,7 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
             return message + m
         timepoint = tselect[1] - IDX_OFFSET
 
-    allChannels = channels[0]
+    allChannels = not channels[0]
 
     if allChannels:
         readoutCh = range(image.getSizeC())
@@ -181,7 +181,7 @@ def processImages(client, scriptParams):
     ids = scriptParams['IDs']
     ftset = scriptParams['Feature_set']
 
-    channels = (scriptParams['Readout_All_Channels'],
+    channels = (scriptParams['Select_Readout_Channel_instead_of_all'],
                 scriptParams['Select_Readout_Channel'],
                 scriptParams['Select_Reference_Channel'])
 
@@ -283,9 +283,11 @@ def runScript():
                        values=[rstring('slf33'), rstring('slf34')],
                        default='slf33'),
 
-        scripts.Bool('Readout_All_Channels', optional=False, grouping='3',
-                     description='Which readout channel(s) to use',
-                     default=True),
+        scripts.Bool(
+            'Select_Readout_Channel_instead_of_all',
+            optional=False, grouping='3',
+            description='Select a readout channel instead of all channels',
+            default=False),
 
         scripts.Long(
             'Select_Readout_Channel', optional=False, grouping='3.1',

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -116,7 +116,7 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
     else:
         existing = listExistingCZTS(conn, imageId, ftset)
 
-    if zselect[0]:
+    if not zselect[0]:
         zslice = image.getSizeZ() / 2
     else:
         if (zselect[1] < IDX_OFFSET or
@@ -126,7 +126,7 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
             return message + m
         zslice = zselect[1] - IDX_OFFSET
 
-    if tselect[0]:
+    if not tselect[0]:
         timepoint = image.getSizeT() / 2
     else:
         if (tselect[1] < IDX_OFFSET or
@@ -185,8 +185,10 @@ def processImages(client, scriptParams):
                 scriptParams['Select_Readout_Channel'],
                 scriptParams['Select_Reference_Channel'])
 
-    zselect = (scriptParams['Use_Middle_Z'], scriptParams['Select_Z'])
-    tselect = (scriptParams['Use_Middle_T'], scriptParams['Select_T'])
+    zselect = (scriptParams['Select_Z_instead_of_middle'],
+               scriptParams['Select_Z'])
+    tselect = (scriptParams['Select_T_instead_of_middle'],
+               scriptParams['Select_T'])
 
     if scriptParams['Enable_Advanced_Options']:
         recalc = scriptParams['Recalculate_Existing_Features']
@@ -298,9 +300,10 @@ def runScript():
             default=IDX_OFFSET + 1),
 
 
-        scripts.Bool('Use_Middle_Z', optional=False, grouping='5',
-                       description='Which Z-slice to use',
-                       default=True),
+        scripts.Bool(
+            'Select_Z_instead_of_middle', optional=False, grouping='5',
+            description='Select a Z-slice instead of the default (middle)',
+            default=False),
 
         scripts.Long(
             'Select_Z', optional=False, grouping='5.1',
@@ -308,9 +311,10 @@ def runScript():
             default=-1),
 
 
-        scripts.Bool('Use_Middle_T', optional=False, grouping='6',
-                     description='Which timepoint to use',
-                     default=True),
+        scripts.Bool(
+            'Select_T_instead_of_middle', optional=False, grouping='6',
+            description='Select a timepoint instead of the default (middle)',
+            default=False),
 
         scripts.Long(
             'Select_T', optional=False, grouping='6.1',

--- a/scripts/Omero_Searcher_Rebuild_ContentDB.py
+++ b/scripts/Omero_Searcher_Rebuild_ContentDB.py
@@ -118,14 +118,14 @@ def saveToCdb(conn, ftset, cdbs):
         superids = ''.join('\t%d.%d.%d.%d.%d\n' % s for s in
                            zip(*(cdb.iid, cdb.px, cdb.c, cdb.z, cdb.t)))
 
-    if answer:
-        sys.stdout.write('Added ContentDB features (scale:%e) from:\n%s' % (
-                cdb.scale, superids))
-    else:
-        m = 'Failed to add ContentDB features (user:%d scale:%e) from:\n%s' % (
-            cdb.uid, cdb.scale, superids)
-        sys.stderr.write(m)
-        message += m
+        if answer:
+            sys.stdout.write('Added ContentDB features (scale:%e) from:\n%s' % (
+                    cdb.scale, superids))
+        else:
+            m = 'Failed to add ContentDB features (user:%d scale:%e) from:\n%s' % (
+                cdb.uid, cdb.scale, superids)
+            sys.stderr.write(m)
+            message += m
 
     return message
 

--- a/templates/searcher/contentsearch/search_error.html
+++ b/templates/searcher/contentsearch/search_error.html
@@ -5,7 +5,7 @@
 {% block search_results %}
 
         <!-- from search_details.html -->
-    <div>
+    <div class="error">
       {{ message }}
     </div>
 

--- a/templates/searcher/plugin_config/right_search_form.js.html
+++ b/templates/searcher/plugin_config/right_search_form.js.html
@@ -7,16 +7,16 @@ $(document).ready(function() {
         load_tab_content: function(selected, obj_dtype, obj_id) {    // This MUST be defined
             var imageIds = [];
             for (var i=0; i<selected.length; i++) {
-		// IDs will be in the form image-<id> if coming from the
-		// standard middle pane, or image-<id>-<superid> if coming
-		// from the OMERO.searcher middle pane
-		var sid = selected[i]["id"].split('-');
-		if (sid.length > 2) {
-		    imageIds.push(sid[0] + 'superid=' +  sid[2]);
-		}
-		else {
-		    imageIds.push(sid.join('='));
-		}
+                // IDs will be in the form image-<id> if coming from the
+                // standard middle pane, or image-<id>-<superid> if coming
+                // from the OMERO.searcher middle pane
+                var sid = selected[i]["id"].split('-');
+                if (sid.length > 2) {
+                    imageIds.push(sid[0] + 'superid=' +  sid[2]);
+                }
+                else {
+                    imageIds.push(sid.join('='));
+                }
             }
             queryString = imageIds.join("&");
             $(this).load('{% url right_plugin_search_form %}?' + queryString);

--- a/templates/searcher/plugin_config/right_search_form.js.html
+++ b/templates/searcher/plugin_config/right_search_form.js.html
@@ -10,7 +10,7 @@ $(document).ready(function() {
 		// IDs will be in the form image-<id> if coming from the
 		// standard middle pane, or image-<id>-<superid> if coming
 		// from the OMERO.searcher middle pane
-		sid = selected[i]["id"].split('-');
+		var sid = selected[i]["id"].split('-');
 		if (sid.length > 2) {
 		    imageIds.push(sid[0] + 'superid=' +  sid[2]);
 		}

--- a/views.py
+++ b/views.py
@@ -266,7 +266,7 @@ def contentsearch( request, conn=None, **kwargs):
         context = {'template':
                        'searcher/contentsearch/search_error.html'}
         context['message'] = (
-            'The ContentDB for feature-set %s could not be found.'
+            'The ContentDB for feature-set %s could not be found. '
             'Have you calculated any features?') % ftset
         return context
 


### PR DESCRIPTION
Fixes in response to comments on #3 including:
- Declaring JS variable correctly
- Larger error messages

This requires pyslid with icaoberg/pyslid#4 to fix the incorrect pyslid C/Z/T [Trac 11098](https://trac.openmicroscopy.org.uk/ome/ticket/11098).

Additional feature calculation script improvements:
- Less verbose messages in activities dialog
- Advanced feature calculation options are now in a separate section of the script dialog, including:
- Provide option to calculate features without updating the central ContentDB, this allows multiple feature calculation processes to be run in parallel but requires the Rebuild ContentDB script to be manually run afterwards.
  - Skip testing this if you want, since it's for expert users only.

Fixes for the ContentDB rebuild script [Trac #11010](http://trac.openmicroscopy.org.uk/ome/ticket/11010)
- If you _want_ to test this probably the best way is to delete all features, run the ContentDB rebuild script (which will now create an empty ContentDB), create your features selecting the `Disable ContentDB Update` option, then run the ContentDB rebuild script. Then check everything works.
