### PR TITLE
User filtering (#10988)

### DIFF
--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -129,6 +129,23 @@
             </select>
         </div>
 
+	<div>
+            <label for="limit_users">Limit to users:</label>
+            <div style="margin-left:20px">
+                <div style="float:left">
+                    <input type="checkbox" checked="true" name="limit_users" value="All">All</input>
+                </div>
+                <div style="float:left">
+                    {% for userid, username in users.items %}
+                        <input type="checkbox" checked="{% if userid in limit_users %}true{% else %}false{% endif %}" name="limit_users"
+			    value="{{userid}}">{{username}}</input>
+                    {% endfor %}
+                </div>
+                <div style="clear:both"></div>
+            </div>
+	</div>
+
+
         <input style="float:right" id="doSearch" type="button" value="Do Search"/> 
 
         <div style="clear:both; padding:0px"></div>

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -131,16 +131,15 @@
 
         <div>
             <label for="limit_users">Limit to users:</label>
-            <div style="margin-left:20px">
-                <div style="float:left">
-                    {% for userid, username in users.items %}
+            <div class="search_filter_selector">
+                {% for userid, username in users.items %}
+                    <div style="margin-left:20px">
                         <input type="checkbox"
                             {% if userid in limit_users %}checked="checked"{% endif %}
                             name="limit_users" value="{{userid}}">{{username}}
                         </input>
-                    {% endfor %}
-                </div>
-                <div style="clear:both"></div>
+                    </div>
+                {% endfor %}
             </div>
         </div>
 

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -129,21 +129,20 @@
             </select>
         </div>
 
-	<div>
+        <div>
             <label for="limit_users">Limit to users:</label>
             <div style="margin-left:20px">
                 <div style="float:left">
-                    <input type="checkbox" checked="true" name="limit_users" value="All">All</input>
-                </div>
-                <div style="float:left">
                     {% for userid, username in users.items %}
-                        <input type="checkbox" checked="{% if userid in limit_users %}true{% else %}false{% endif %}" name="limit_users"
-			    value="{{userid}}">{{username}}</input>
+                        <input type="checkbox"
+                            {% if userid in limit_users %}checked="checked"{% endif %}
+                            name="limit_users" value="{{userid}}">{{username}}
+                        </input>
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>
             </div>
-	</div>
+        </div>
 
 
         <input style="float:right" id="doSearch" type="button" value="Do Search"/> 

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -130,7 +130,7 @@
         </div>
 
         <div>
-            <label for="limit_users">Limit to users:</label>
+            <label for="limit_users">Filter by users:</label>
             <div class="search_filter_selector">
                 {% for userid, username in users.items %}
                     <div style="margin-left:20px">

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -81,6 +81,19 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             $('input[name="limit_users_all"]').prop('checked', all_checked);
         });
 
+        $(".search_filter_toggle").click(function(event){
+            event.preventDefault();
+            $(this).next().slideToggle(500, function(){
+                $(this).prev().text($(this).is(':visible')?
+                    '[\u2013] hide' : '[+] show');
+            })
+        });
+
+        // Hide by default
+        $(".search_filter_toggle").next().hide(0, function(){
+            $(this).prev().text('[+] show');
+        });
+
     });    
 
 </script>
@@ -150,6 +163,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
         <div id="search_filter_users">
             <label for="limit_users">Filter by users:</label>
+            <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px" class="search_filter_selector">
                 <input type="checkbox" checked="true" name="limit_users_all" value="All">All</input>
                 <div>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -64,7 +64,26 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             $input.val(czt);
             $span.text(czt);
         });
+
+        $('input[name="limit_users"]').change(function() {
+            if (this.value == "All") {
+                var all_checked = this.checked;
+                $('input[name="limit_users"][value!="All"]').each(function() {
+                    this.checked = all_checked;
+                });
+            }
+            else {
+                var all_checked = true;
+                $('input[name="limit_users"][value!="All"]').each(function() {
+                    all_checked = all_checked && this.checked;
+                });
+                $('input[name="limit_users"][value="All"]').
+                    prop('checked', all_checked);
+            }
+        });
+
     });    
+
 </script>
 
 <style type="text/css">

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -150,18 +150,17 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
         <div id="search_filter_users">
             <label for="limit_users">Limit to users:</label>
-            <div style="margin-left:20px">
-                <div style="float:left">
-                    <input type="checkbox" checked="true" name="limit_users_all" value="All">All</input>
-                </div>
-                <div style="float:left">
+            <div style="margin-left:20px" class="search_filter_selector">
+                <input type="checkbox" checked="true" name="limit_users_all" value="All">All</input>
+                <div>
                     {% for userid, username in users.items %}
-                        <input type="checkbox" checked="checked"
-                            name="limit_users" value="{{userid}}">
-                            {{username}}</input>
+                        <div style="margin-left:20px">
+                            <input type="checkbox" checked="checked"
+                                name="limit_users" value="{{userid}}"
+                                >{{ username }}</input>
+                        </div>
                     {% endfor %}
                 </div>
-                <div style="clear:both"></div>
             </div>
         </div>
 

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -130,6 +130,22 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
+        <div>
+            <label for="limit_users">Limit to users:</label>
+            <div style="margin-left:20px">
+                <div style="float:left">
+                    <input type="checkbox" checked="true" name="limit_users" value="All">All</input>
+                </div>
+                <div style="float:left">
+                    {% for userid, username in users.items %}
+                        <input type="checkbox" checked="true" name="limit_users"
+				            value="{{userid}}">{{username}}</input>
+                    {% endfor %}
+                </div>
+                <div style="clear:both"></div>
+            </div>
+        </div>
+
         <input style="float:right" type="submit" value="Do Search"/> 
 
         <div style="clear:both"></div>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -149,7 +149,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         </div>
 
         <div id="search_filter_users">
-            <label for="limit_users">Limit to users:</label>
+            <label for="limit_users">Filter by users:</label>
             <div style="margin-left:20px" class="search_filter_selector">
                 <input type="checkbox" checked="true" name="limit_users_all" value="All">All</input>
                 <div>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -65,21 +65,20 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             $span.text(czt);
         });
 
-        $('input[name="limit_users"]').change(function() {
-            if (this.value == "All") {
-                var all_checked = this.checked;
-                $('input[name="limit_users"][value!="All"]').each(function() {
-                    this.checked = all_checked;
-                });
-            }
-            else {
-                var all_checked = true;
-                $('input[name="limit_users"][value!="All"]').each(function() {
-                    all_checked = all_checked && this.checked;
-                });
-                $('input[name="limit_users"][value="All"]').
-                    prop('checked', all_checked);
-            }
+        var sfu = $('#search_filter_users');
+        sfu.find('input[name="limit_users_all"]').change(function() {
+            var all_checked = this.checked;
+            sfu.find('input[name="limit_users"]').each(function() {
+                this.checked = all_checked;
+            });
+        });
+
+        sfu.find('input[name="limit_users"]').change(function() {
+            var all_checked = true;
+            sfu.find('input[name="limit_users"]').each(function() {
+                all_checked = all_checked && this.checked;
+            });
+            $('input[name="limit_users_all"]').prop('checked', all_checked);
         });
 
     });    
@@ -149,16 +148,17 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
-        <div>
+        <div id="search_filter_users">
             <label for="limit_users">Limit to users:</label>
             <div style="margin-left:20px">
                 <div style="float:left">
-                    <input type="checkbox" checked="true" name="limit_users" value="All">All</input>
+                    <input type="checkbox" checked="true" name="limit_users_all" value="All">All</input>
                 </div>
                 <div style="float:left">
                     {% for userid, username in users.items %}
-                        <input type="checkbox" checked="true" name="limit_users"
-				            value="{{userid}}">{{username}}</input>
+                        <input type="checkbox" checked="checked"
+                            name="limit_users" value="{{userid}}">
+                            {{username}}</input>
                     {% endfor %}
                 </div>
                 <div style="clear:both"></div>

--- a/views.py
+++ b/views.py
@@ -370,16 +370,17 @@ def contentsearch( request, conn=None, **kwargs):
 
     def image_batch_load(conn, im_ids_sorted, numret):
         """
-        We don't want to load all images, but since we'll filter out soem images
-        we don't know how many to load, so read in chunks until we have the
-        required number of images.
+        We don't want to load all images, but since we'll filter out some we
+        don't know how many to load, and it's also possible for images to
+        have been deleted but remain in the contentDB.
+        Read in chunks until we have the required number of images.
         """
         img_map = {}
 
         # We need to choose the batch size
         # Remember getObjects() returns objects in an unspecified order, so we
         # must iterate through the entire result and re-order
-        batch_size = 10
+        batch_size = numret
 
         i = 0
         while i < len(im_ids_sorted):

--- a/views.py
+++ b/views.py
@@ -208,7 +208,10 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
         context['dataset'] = conn.getObject("Dataset", dId)
     context['fset'] = request.POST.get("featureset_Name")
     context['numret'] = request.POST.get("NumRetrieve")
-    context['limit_users'] = request.POST.getlist("limit_users")
+
+    limit_users = request.POST.getlist("limit_users")
+    limit_users = [int(x) for x in limit_users]
+    context['limit_users'] = limit_users
 
     users = getGroupMembers(conn, request)
     context['users'] = users
@@ -267,10 +270,7 @@ def contentsearch( request, conn=None, **kwargs):
             }
         return context
 
-    if 'All' in limit_users:
-        limit_users = None
-    else:
-        limit_users = [int(x) for x in limit_users]
+    limit_users = [int(x) for x in limit_users]
     logger.debug('Got limit_users: %s', limit_users)
 
     superIds = request.POST.getlist("superIds")
@@ -366,7 +366,7 @@ def contentsearch( request, conn=None, **kwargs):
     context = {'template': 'searcher/contentsearch/searchresult.html'}
 
     def filter_image(im):
-        return limit_users is None or im.getOwner().id in limit_users
+        return im.getOwner().id in limit_users
 
     def image_batch_load(conn, im_ids_sorted, numret):
         """

--- a/views.py
+++ b/views.py
@@ -81,6 +81,23 @@ def getIdCztPnFromImageIds(imageIds, reqvars):
     return idCztPn
 
 
+def getGroupMembers(conn, request):
+    """
+    Get a list of user-ids and names
+    """
+
+    gid = conn.SERVICE_OPTS.getOmeroGroup()
+    if gid >= 0:
+        group = conn.getObject('ExperimenterGroup', gid)
+    else:
+        logger.warn('Failed to get group from SERVICE_OPTS.getOmeroGroup, using getGroupFromContext')
+        group = conn.getGroupFromContext()
+    logger.debug('group: %s', group)
+    users = dict((x.child.id.val, x.child.getOmeName().val)
+                    for x in group.copyGroupExperimenterMap())
+    return users
+
+
 def listAvailableCZTS(conn, imageId, ftset):
     """
     List the available CZT and scales for features associated with an image
@@ -118,7 +135,7 @@ def index (request, conn=None, **kwargs):
     return {'template': 'searcher/index.html'}
 
 
-@login_required()
+@login_required(setGroupContext=True)
 @render_response()
 def right_plugin_search_form (request, conn=None, **kwargs):
     """
@@ -165,11 +182,15 @@ def right_plugin_search_form (request, conn=None, **kwargs):
                     })
 
     context['images'] = images
+
+    users = getGroupMembers(conn, request)
+    context['users'] = users
+
     logger.debug('Context:%s', context)
     return context
 
 
-@login_required()
+@login_required(setGroupContext=True)
 @render_response()
 def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negId = None, conn=None, **kwargs):
     """
@@ -187,6 +208,10 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
         context['dataset'] = conn.getObject("Dataset", dId)
     context['fset'] = request.POST.get("featureset_Name")
     context['numret'] = request.POST.get("NumRetrieve")
+    context['limit_users'] = request.POST.getlist("limit_users")
+
+    users = getGroupMembers(conn, request)
+    context['users'] = users
 
     superIds = request.POST.getlist("superIds")
     if superIds:
@@ -220,7 +245,7 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
 
 
 # import omeroweb.searcher.searchContent as searchContent   TODO: import currently failing
-@login_required()
+@login_required(setGroupContext=True)
 @render_response()
 def contentsearch( request, conn=None, **kwargs):
 
@@ -233,6 +258,20 @@ def contentsearch( request, conn=None, **kwargs):
     fset = request.POST.get("featureset_Name")
     numret = request.POST.get("NumRetrieve")
     numret = int(numret)
+
+    limit_users = request.POST.getlist("limit_users")
+    if len(limit_users) == 0:
+        context = {
+            'template': 'searcher/contentsearch/search_error.html',
+            'message': 'No users selected'
+            }
+        return context
+
+    if 'All' in limit_users:
+        limit_users = None
+    else:
+        limit_users = [int(x) for x in limit_users]
+    logger.debug('Got limit_users: %s', limit_users)
 
     superIds = request.POST.getlist("superIds")
     logger.debug('Got superIDs: %s', superIds)
@@ -321,17 +360,43 @@ def contentsearch( request, conn=None, **kwargs):
         raise
 
     im_ids_sorted = [r[0] for r in final_result]
-    im_ids_sorted = im_ids_sorted[:numret]
     logger.debug('contentsearch im_ids_sorted:%s', im_ids_sorted)
 
 
     context = {'template': 'searcher/contentsearch/searchresult.html'}
 
-    imgMap = {}
-    imgIds = [int(i.split(".")[0]) for i in im_ids_sorted]
-    imgs = conn.getObjects("Image", imgIds)     # not sorted!
-    for i in imgs:
-        imgMap[i.getId()] = i
+    def filter_image(im):
+        return limit_users is None or im.getOwner().id in limit_users
+
+    def image_batch_load(conn, im_ids_sorted, numret):
+        """
+        We don't want to load all images, but since we'll filter out soem images
+        we don't know how many to load, so read in chunks until we have the
+        required number of images.
+        """
+        img_map = {}
+
+        # We need to choose the batch size
+        # Remember getObjects() returns objects in an unspecified order, so we
+        # must iterate through the entire result and re-order
+        batch_size = 10
+
+        i = 0
+        while i < len(im_ids_sorted):
+            batch_sids = im_ids_sorted[i:i + batch_size]
+            batch_ids = [int(id.split('.')[0]) for id in batch_sids]
+            batch_ims = conn.getObjects('Image', batch_ids)
+            i += batch_size
+
+            img_map.update((im.id, im) for im in batch_ims if filter_image(im))
+            if len(img_map) >= numret:
+                break
+
+        logger.debug('img_map:%s', img_map)
+        return img_map
+
+
+    imgMap = image_batch_load(conn, im_ids_sorted, numret)
 
     images = []
     ranki = 0
@@ -348,6 +413,8 @@ def contentsearch( request, conn=None, **kwargs):
                 'ranki': ranki,
                 'superid': i,
                 'czt': czt})
+        if ranki == numret:
+            break
     context['images'] = images
     #logger.debug('contentsearch images:%s', images)
 


### PR DESCRIPTION
Added filtering by users within a group [Trac #10988](http://trac.openmicroscopy.org.uk/ome/ticket/10988). When running a search you can optionally restrict your search to images owned by a subset of users.

If you're calculating features in a multi-user group make sure you only calculate them as a **group owner** including on other users's images, otherwise you _may_ get permissions errors.
