### PR TITLE
Additional filtering, UI improvements

### DIFF
--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -144,7 +144,7 @@
         </div>
 
         <div>
-            <label for="limit_datasets">Filter by users:</label>
+            <label for="limit_datasets">Filter by datasets:</label>
             <div class="search_filter_selector">
                 {% for projectid, projectdata in projects.items %}
                     {% for dsid, dsname in projectdata.1.items %}
@@ -152,10 +152,18 @@
                         <input type="checkbox"
                             {% if dsid in limit_datasets %}checked="checked"{% endif %}
                             name="limit_datasets"
-			    value="{{dsid}}">{{projectdata.0}}/{{dsname}}
+                            value="{{dsid}}">{{projectdata.0}}/{{dsname}}
                         </input>
                     </div>
                     {% endfor %}
+                {% endfor %}
+                {% for dsid, dsname in datasets.items %}
+                <div style="margin-left:20px">
+                    <input type="checkbox"
+                        {% if dsid in limit_datasets %}checked="checked"{% endif %}
+                        name="limit_datasets"
+                        value="{{dsid}}">{{dsname}}</input>
+                </div>
                 {% endfor %}
             </div>
         </div>

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -128,11 +128,11 @@
             <label for="limit_users">Filter by users:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
-                {% for userid, username in users.items %}
+                {% for user in users %}
                     <div style="margin-left:20px">
                         <input type="checkbox"
-                            {% if userid in limit_users %}checked="checked"{% endif %}
-                            name="limit_users" value="{{userid}}">{{username}}
+                            {% if user.0 in limit_users %}checked="checked"{% endif %}
+                            name="limit_users" value="{{user.0}}">{{user.1}}
                         </input>
                     </div>
                 {% endfor %}
@@ -143,23 +143,23 @@
             <label for="limit_datasets">Filter by datasets:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
-                {% for projectid, projectdata in projects.items %}
-                    {% for dsid, dsname in projectdata.1.items %}
+                {% for proj in projects %}
+                    {% for dset in proj.2 %}
                     <div style="margin-left:20px">
                         <input type="checkbox"
-                            {% if dsid in limit_datasets %}checked="checked"{% endif %}
+                            {% if dset.0 in limit_datasets %}checked="checked"{% endif %}
                             name="limit_datasets"
-                            value="{{dsid}}">{{projectdata.0}}/{{dsname}}
+                            value="{{dset.0}}">{{proj.1}}/{{dset.1}}
                         </input>
                     </div>
                     {% endfor %}
                 {% endfor %}
-                {% for dsid, dsname in datasets.items %}
+                {% for dset in datasets %}
                 <div style="margin-left:20px">
                     <input type="checkbox"
-                        {% if dsid in limit_datasets %}checked="checked"{% endif %}
+                        {% if dset.0 in limit_datasets %}checked="checked"{% endif %}
                         name="limit_datasets"
-                        value="{{dsid}}">{{dsname}}</input>
+                        value="{{dset.0}}">{{dset.1}}</input>
                 </div>
                 {% endfor %}
             </div>
@@ -169,11 +169,11 @@
             <label for="limit_channelidxs">Filter by channel indices:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
-                {% for chid, chname in channelidxs.items %}
+                {% for ch in channelidxs %}
                     <div style="margin-left:20px">
                         <input type="checkbox"
-                            {% if chid in limit_channelidxs %}checked="checked"{% endif %}
-                            name="limit_channelidxs" value="{{chid}}">{{chname}}
+                            {% if ch.0 in limit_channelidxs %}checked="checked"{% endif %}
+                            name="limit_channelidxs" value="{{ch.0}}">{{ch.1}}
                         </input>
                     </div>
                 {% endfor %}

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -180,6 +180,21 @@
             </div>
         </div>
 
+        <div>
+            <label for="limit_channelnames">Filter by channel names:</label>
+            <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
+            <div class="search_filter_selector">
+                {% for ch in channelnames %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox"
+                            {% if ch.0 in limit_channelnames %}checked="checked"{% endif %}
+                            name="limit_channelnames" value="{{ch.0}}">{{ch.1}}
+                        </input>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+
 
         <input style="float:right" id="doSearch" type="button" value="Do Search"/> 
 

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -166,14 +166,14 @@
         </div>
 
         <div>
-            <label for="limit_channels">Filter by channels:</label>
+            <label for="limit_channelidxs">Filter by channel indices:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
-                {% for chid, chname in channels.items %}
+                {% for chid, chname in channelidxs.items %}
                     <div style="margin-left:20px">
                         <input type="checkbox"
-                            {% if chid in limit_channels %}checked="checked"{% endif %}
-                            name="limit_channels" value="{{chid}}">{{chname}}
+                            {% if chid in limit_channelidxs %}checked="checked"{% endif %}
+                            name="limit_channelidxs" value="{{chid}}">{{chname}}
                         </input>
                     </div>
                 {% endfor %}

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -35,6 +35,22 @@
                 },
             })
             .submit();  // on initial load, do first search by submitting immediately
+
+
+            $(".search_refine_toggle").click(function(event){
+                event.preventDefault();
+                $(this).next().slideToggle(500, function(){
+                    $(this).prev().text($(this).is(':visible')?
+                        '[\u2013] hide' : '[+] show');
+                })
+            });
+
+            // Hide by default
+
+            $(".search_refine_toggle").next().hide(0, function(){
+                $(this).prev().text('[+] show');
+            });
+
         });
 
     </script>
@@ -110,6 +126,7 @@
 
         <div>
             <label for="limit_users">Filter by users:</label>
+            <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
                 {% for userid, username in users.items %}
                     <div style="margin-left:20px">
@@ -124,6 +141,7 @@
 
         <div>
             <label for="limit_datasets">Filter by datasets:</label>
+            <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
                 {% for projectid, projectdata in projects.items %}
                     {% for dsid, dsname in projectdata.1.items %}
@@ -149,6 +167,7 @@
 
         <div>
             <label for="limit_channels">Filter by channels:</label>
+            <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
                 {% for chid, chname in channels.items %}
                     <div style="margin-left:20px">

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -93,30 +93,9 @@
     <form id="content_search" class="content_search" method="POST" action="{% url contentsearch %}">
 
         <div>
-            <table class="bk_table">
-                <thead> 
-                    <tr> 
-                        <th width=50%>{% trans "Featureset name" %}</th> 
-                        <th width=50%>{% trans "Dataset" %}</th> 
-                    </tr> 
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>
-                            <input name="featureset_Name" value="{{ fset }}" style="display:none"/>
-                            {{ fset }}
-                        </td>
-                        <td>
-                            {% if dataset %}
-                                {{ dataset.getId }}: {{ dataset.getName }}
-                                <input name="dataset_ID" value="{{ dataset.getId }}" style="display:none"/>
-                            {% else %}
-                                Entire DB
-                            {% endif %}
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+            <label>Feature-set:</label>
+            <input name="featureset_Name" value="{{ fset }}" type="hidden" />
+            {{ fset }}
         </div>
 
         <div>

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -26,11 +26,13 @@
                 });
                 $searchImagesTable.prepend($tbody);
 
+                $("#content_search").submit();
+            });
+
+            $("#content_search").submit(function() {
                 $("div#content_details").append(
                     '<div class="loading_center" style="position:absolute;width:100%;top:0px;background-color:rgba(255,255,255,0.75);"><p>Loading... please wait.</p><img src ="{% static "webgateway/img/spinner_big.gif" %}"/></div>'
                 ).scrollTop(0).scrollLeft(0);
-
-                $("#content_search").submit();
             });
 
             // Form ajax handling - load results to central panel.

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -44,6 +44,24 @@
             .submit();  // on initial load, do first search by submitting immediately
 
 
+            $('input.search_refine_item').change(function() {
+                var all_checked = true;
+                var parent = $(this).parent().parent()
+                parent.children().children('input.search_refine_item').each(function() {
+                    all_checked = all_checked && this.checked;
+                });
+                parent.find('input.search_refine_all').prop('checked', all_checked);
+            });
+
+            $('input.search_refine_all').change(function() {
+                var all_checked = this.checked;
+                $(this).parent().children().children('input.search_refine_item')
+                    .each(function() {
+                        this.checked = all_checked;
+                    });
+            });
+
+
             $(".search_refine_toggle").click(function(event){
                 event.preventDefault();
                 $(this).next().slideToggle(500, function(){
@@ -61,15 +79,20 @@
 
             $("#enable_search_refines").change(function() {
                 if (this.checked) {
-                    $(".search_filter_refine").slideDown();
+                    $(".search_refine_group").slideDown();
                 }
                 else {
-                    $(".search_filter_refine").slideUp();
+                    $(".search_refine_group").slideUp();
                 }
             });
             if (!$("#enable_search_refines").prop('checked')) {
-                $(".search_filter_refine").hide();
+                $(".search_refine_group").hide();
             }
+
+            // Finally we need to set the initial state of the parent 'All'
+            // checkboxes. For now just set a change event on every checkbox.
+            // TODO: We should only trigger a change even once per group
+            $('input.search_refine_item').trigger('change');
 
         });
 
@@ -150,79 +173,104 @@
                 additional search filters (may slow down queries).</input>
         </div>
 
-        <div class="search_filter_refine">
-            <label for="limit_users">Filter by users:</label>
+        <div class="search_refine_group">
+            <label for="limit_users">Filter by user:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
-            <div class="search_filter_selector">
-                {% for user in users %}
-                    <div style="margin-left:20px">
-                        <input type="checkbox"
-                            {% if user.0 in limit_users %}checked="checked"{% endif %}
-                            name="limit_users" value="{{user.0}}">{{user.1}}
-                        </input>
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
+            <div style="margin-left:20px">
+                <input type="checkbox" name="limit_users_all"
+                    class="search_refine_all" value="All">All</input>
 
-        <div class="search_filter_refine">
-            <label for="limit_datasets">Filter by datasets:</label>
-            <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
-            <div class="search_filter_selector">
-                {% for proj in projects %}
-                    {% for dset in proj.2 %}
-                    <div style="margin-left:20px">
-                        <input type="checkbox"
-                            {% if dset.0 in limit_datasets %}checked="checked"{% endif %}
-                            name="limit_datasets"
-                            value="{{dset.0}}">{{proj.1}}/{{dset.1}}
-                        </input>
-                    </div>
-                    {% endfor %}
-                {% endfor %}
-                {% for dset in datasets %}
+                {% for user in users %}
                 <div style="margin-left:20px">
                     <input type="checkbox"
-                        {% if dset.0 in limit_datasets %}checked="checked"{% endif %}
-                        name="limit_datasets"
-                        value="{{dset.0}}">{{dset.1}}</input>
+                        {% if user.2 %}checked="checked"{% endif %}
+                        class="search_refine_item"
+                        name="limit_users" value="{{user.0}}"
+                        >{{user.1}}</input>
                 </div>
                 {% endfor %}
             </div>
         </div>
 
-        <div class="search_filter_refine">
-            <label for="limit_channelidxs">Filter by channel indices:</label>
+        <div class="search_refine_group">
+            <label for="limit_datasets">Filter by project/dataset:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
-            <div class="search_filter_selector">
+            <div style="margin-left:20px">
+
+                {% for proj in projects %}
+                <div>
+                    <input type="checkbox"
+                        class="search_refine_all" name="project"
+                        value="{{proj.0}}">{{proj.1}}</input>
+
+                    {% for dset in proj.2 %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox"
+                            {% if dset.2 %}checked="checked"{% endif %}
+                            class="search_refine_item" name="limit_datasets"
+                            value="{{dset.0}}">{{dset.1}}</input>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+
+                <div>
+                    <input type="checkbox"
+                        class="search_refine_all" name="project"
+                        value="[No project]">[No project]</input>
+
+                    {% for dset in datasets %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox"
+                            {% if dset.2 %}checked="checked"{% endif %}
+                            class="search_refine_item" name="limit_datasets"
+                            value="{{dset.0}}">{{dset.1}}</input>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+
+        <div class="search_refine_group">
+            <label for="limit_channelidxs">Filter by channel index:</label>
+            <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
+            <div style="margin-left:20px">
+                <input type="checkbox" name="limit_channelidxs_all"
+                    class="search_refine_all" value="All">All</input>
+
                 {% for ch in channelidxs %}
-                    <div style="margin-left:20px">
-                        <input type="checkbox"
-                            {% if ch.0 in limit_channelidxs %}checked="checked"{% endif %}
-                            name="limit_channelidxs" value="{{ch.0}}">{{ch.1}}
-                        </input>
-                    </div>
+                <div style="margin-left:20px">
+                    <input type="checkbox"
+                        {% if ch.2 %}checked="checked"{% endif %}
+                        class="search_refine_item"
+                        name="limit_channelidxs" value="{{ch.0}}">{{ch.1}}
+                    </input>
+                </div>
                 {% endfor %}
             </div>
         </div>
 
-        <div class="search_filter_refine">
-            <label for="limit_channelnames">Filter by channel names:</label>
+        <div class="search_refine_group">
+            <label for="limit_channelnames">Filter by channel name:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
-            <div class="search_filter_selector">
+            <div style="margin-left:20px">
+                <input type="checkbox" name="limit_channelnames_all"
+                    class="search_refine_all" value="All">All</input>
+
                 {% for ch in channelnames %}
-                    <div style="margin-left:20px">
-                        <input type="checkbox"
-                            {% if ch.0 in limit_channelnames %}checked="checked"{% endif %}
-                            name="limit_channelnames" value="{{ch.0}}">{{ch.1}}
-                        </input>
+                <div style="margin-left:20px">
+                    <input type="checkbox"
+                        {% if ch.2 %}checked="checked"{% endif %}
+                        class="search_refine_item"
+                        name="limit_channelnames" value="{{ch.0}}"
+                        >{{ch.1}}</input>
                     </div>
                 {% endfor %}
             </div>
         </div>
 
 
-        <input style="float:right" id="doSearch" type="button" value="Do Search"/> 
+        <input style="float:right" id="doSearch" type="button" value="Refine Results"/>
 
         <div style="clear:both; padding:0px"></div>
         <hr/>

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -122,8 +122,7 @@
 <div id="searching">
     <div class="left_panel_inner">
 
-    <h1> {% trans "Search again with additional image(s)" %}            <span id="searching_again_description" title="Search again - <small>Performs another round of search by image content. Using the previous settings (selected image(s), featureset, # retrieved images, and dataset), you can include additional images to the search query by selecting images. <br/><br/>
-            For example, if you have some images that you don't like among the current result, you can add those images as negative samples and do another round of search.</small>"><img src="{% static "webclient/images/help16.png" %}" /></span></h1>
+    <h1>{% trans "Search again with additional image(s)" %}</h1>
 
 
     <form id="content_search" class="content_search" method="POST" action="{% url contentsearch %}">

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -147,6 +147,20 @@
             </div>
         </div>
 
+        <div>
+            <label for="limit_channels">Filter by channels:</label>
+            <div class="search_filter_selector">
+                {% for chid, chname in channels.items %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox"
+                            {% if chid in limit_channels %}checked="checked"{% endif %}
+                            name="limit_channels" value="{{chid}}">{{chname}}
+                        </input>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+
 
         <input style="float:right" id="doSearch" type="button" value="Do Search"/> 
 

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -143,6 +143,23 @@
             </div>
         </div>
 
+        <div>
+            <label for="limit_datasets">Filter by users:</label>
+            <div class="search_filter_selector">
+                {% for projectid, projectdata in projects.items %}
+                    {% for dsid, dsname in projectdata.1.items %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox"
+                            {% if dsid in limit_datasets %}checked="checked"{% endif %}
+                            name="limit_datasets"
+			    value="{{dsid}}">{{projectdata.0}}/{{dsname}}
+                        </input>
+                    </div>
+                    {% endfor %}
+                {% endfor %}
+            </div>
+        </div>
+
 
         <input style="float:right" id="doSearch" type="button" value="Do Search"/> 
 

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -51,6 +51,19 @@
                 $(this).prev().text('[+] show');
             });
 
+
+            $("#enable_search_refines").change(function() {
+                if (this.checked) {
+                    $(".search_filter_refine").slideDown();
+                }
+                else {
+                    $(".search_filter_refine").slideUp();
+                }
+            });
+            if (!$("#enable_search_refines").prop('checked')) {
+                $(".search_filter_refine").hide();
+            }
+
         });
 
     </script>
@@ -125,6 +138,13 @@
         </div>
 
         <div>
+            <input type="checkbox" id="enable_search_refines"
+                {% if enable_filters %}checked="checked"{% endif %}
+                name="enable_filters" value="enable">Enable
+                additional search filters (may slow down queries).</input>
+        </div>
+
+        <div class="search_filter_refine">
             <label for="limit_users">Filter by users:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
@@ -139,7 +159,7 @@
             </div>
         </div>
 
-        <div>
+        <div class="search_filter_refine">
             <label for="limit_datasets">Filter by datasets:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
@@ -165,7 +185,7 @@
             </div>
         </div>
 
-        <div>
+        <div class="search_filter_refine">
             <label for="limit_channelidxs">Filter by channel indices:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">
@@ -180,7 +200,7 @@
             </div>
         </div>
 
-        <div>
+        <div class="search_filter_refine">
             <label for="limit_channelnames">Filter by channel names:</label>
             <a href="#" title="Show/Hide" class="search_refine_toggle"></a>
             <div class="search_filter_selector">

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -25,6 +25,11 @@
                     $tbody.append($tr);
                 });
                 $searchImagesTable.prepend($tbody);
+
+                $("div#content_details").append(
+                    '<div class="loading_center" style="position:absolute;width:100%;top:0px;background-color:rgba(255,255,255,0.75);"><p>Loading... please wait.</p><img src ="{% static "webgateway/img/spinner_big.gif" %}"/></div>'
+                ).scrollTop(0).scrollLeft(0);
+
                 $("#content_search").submit();
             });
 

--- a/templates/searcher/contentsearch/searchresult.html
+++ b/templates/searcher/contentsearch/searchresult.html
@@ -47,6 +47,9 @@
                 {% endfor %}
             </tbody>
         </table>
+        <div style="text-align:right">
+            {{ performance }}
+        </div>
     </div>
 
 {% endblock %}

--- a/templates/searcher/contentsearch/searchresult.html
+++ b/templates/searcher/contentsearch/searchresult.html
@@ -31,7 +31,7 @@
                         <td>
                             <div style="position:relative">
                                 <input style="display:none" type="text" name="czt-{{ c.id }}" value="{{ c.czt }}" size="3"></input>
-                                <span class="cztEdit" title="Edit Channel/Z/T">{{ c.czt }}</span>
+                                <span class="cztEdit">{{ c.czt }}</span>
                             </div>
                         </td>
                         <td>{{ c.name }}</td>

--- a/templates/searcher/index.html
+++ b/templates/searcher/index.html
@@ -1,26 +1,13 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
-<html> <head>
-<title>Searcher</title>
+<html>
+<head>
+<title>OMERO.searcher</title>
 </head>
 
 <body>
-<h1>OMERO.searcher demonstration page for reviewers</h1>
-<hr>
-<h2>Access and Login</h2>
-<p>
-<p><a href="http://omepslid2.compbio.cs.cmu.edu/webclient">Go to login page</a><!--<br>Username: demo_nm
-<br>Password: nature@u0816-->
+<h1>OMERO.searcher</h1>
 
-<p>This contains an OMERO database with approximately 16,000 images of three marker proteins acquired by automated microscopy.  They are organized into datasets by well and date, and each dataset begins with a string identifying the marker (“ER”, “Mito” and “Nucleus”).  To use the content-based image search, first click the "DATA" button (upper right of page) to show all of the datasets. Select a dataset, select an image within the dataset, and click the magnifying glass icon in the upper left corner. Images with similar patterns will be retrieved.  Note that typically all of the images returned are of the same type as the query.  The number of retrieved images can be changed in the “Content Search” box. The search can be refined by selecting additional positive or negative images from results page and clicking on “Search by image content” in the “Content Search” box.
-<p>
-<p>This account has been set up for testing of the tool only.  Please do not try to delete images or import new images onto this server.
-<p>
-<p>
-<h2>Installation</h2>
-<p>
-<p><a href="http://murphylab.web.cmu.edu/software/searcher/">Download installer</a>
-<p>
-<p>This will install the searcher on top of a previously installed database running OMERO 4.3.3.
-<hr>
+<p>Error: you shouldn't have reached this page directly. Please return to <a href="{% url index %}">OMERO.web</a> to use OMERO.searcher.</p>
+
 </body> 
 </html>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -217,6 +217,25 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
+        <div id="search_filter_channelnames">
+            <label for="limit_channelnames">Filter by channel name:</label>
+            <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
+            <div style="margin-left:20px">
+                <input type="checkbox" checked="true" name="limit_channelnames_all"
+                    class="search_filter_all" value="All">All</input>
+
+                {% for ch in channelnames %}
+                <div style="margin-left:20px">
+                    <input type="checkbox" checked="checked"
+                        class="search_filter_item"
+                        name="limit_channelnames" value="{{ch.0}}"
+                        >{{ ch.1 }}</input>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+
+
         <input style="float:right" type="submit" value="Do Search"/> 
 
         <div style="clear:both"></div>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -168,7 +168,8 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
                 {% for user in users %}
                 <div style="margin-left:20px">
-                    <input type="checkbox" checked="checked"
+                    <input type="checkbox"
+                        {% if user.2 %}checked="checked"{% endif %}
                         class="search_filter_item"
                         name="limit_users" value="{{user.0}}"
                         >{{ user.1 }}</input>
@@ -190,7 +191,8 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
                     {% for dset in proj.2 %}
                     <div style="margin-left:20px">
-                        <input type="checkbox" checked="checked"
+                        <input type="checkbox"
+                            {% if dset.2 %}checked="checked"{% endif %}
                             class="search_filter_item" name="limit_datasets"
                             value="{{dset.0}}">{{ dset.1 }}</input>
                     </div>
@@ -205,7 +207,8 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
                     {% for dset in datasets %}
                     <div style="margin-left:20px">
-                        <input type="checkbox" checked="checked"
+                        <input type="checkbox"
+                            {% if dset.2 %}checked="checked"{% endif %}
                             class="search_filter_item" name="limit_datasets"
                             value="{{dset.0}}">{{ dset.1 }}</input>
                     </div>
@@ -224,7 +227,8 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
                 {% for ch in channelidxs %}
                 <div style="margin-left:20px">
-                    <input type="checkbox" checked="checked"
+                    <input type="checkbox"
+                        {% if ch.2 %}checked="checked"{% endif %}
                         class="search_filter_item"
                         name="limit_channelidxs" value="{{ch.0}}"
                         >{{ ch.1 }}</input>
@@ -242,7 +246,8 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
                 {% for ch in channelnames %}
                 <div style="margin-left:20px">
-                    <input type="checkbox" checked="checked"
+                    <input type="checkbox"
+                        {% if ch.2 %}checked="checked"{% endif %}
                         class="search_filter_item"
                         name="limit_channelnames" value="{{ch.0}}"
                         >{{ ch.1 }}</input>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -105,7 +105,15 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                 $(".search_filter_group").slideUp();
             }
         });
-        $(".search_filter_group").hide();
+
+        if (!$("#enable_search_filter").prop('checked')) {
+            $(".search_filter_group").hide();
+        }
+
+        // Finally we need to set the initial state of the parent 'All'
+        // checkboxes. For now just set a change event on every checkbox.
+        // TODO: We should only trigger a change even once per group
+        $('input.search_filter_item').trigger('change');
 
     });    
 
@@ -163,7 +171,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             <label for="limit_users">Filter by user:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
-                <input type="checkbox" checked="true" name="limit_users_all"
+                <input type="checkbox" name="limit_users_all"
                     class="search_filter_all" value="All">All</input>
 
                 {% for user in users %}
@@ -185,7 +193,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
                 {% for proj in projects %}
                 <div>
-                    <input type="checkbox" checked="checked"
+                    <input type="checkbox"
                         class="search_filter_all" name="project"
                         value="{{proj.0}}">{{proj.1}}</input>
 
@@ -201,7 +209,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                 {% endfor %}
 
                 <div>
-                    <input type="checkbox" checked="checked"
+                    <input type="checkbox"
                         class="search_filter_all" name="project"
                         value="[No project]">[No project]</input>
 
@@ -222,7 +230,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             <label for="limit_channelidxs">Filter by channel index:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
-                <input type="checkbox" checked="true" name="limit_channelidxs_all"
+                <input type="checkbox" name="limit_channelidxs_all"
                     class="search_filter_all" value="All">All</input>
 
                 {% for ch in channelidxs %}
@@ -241,7 +249,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             <label for="limit_channelnames">Filter by channel name:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
-                <input type="checkbox" checked="true" name="limit_channelnames_all"
+                <input type="checkbox" name="limit_channelnames_all"
                     class="search_filter_all" value="All">All</input>
 
                 {% for ch in channelnames %}

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -65,21 +65,23 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             $span.text(czt);
         });
 
-        var sfu = $('#search_filter_users');
-        sfu.find('input[name="limit_users_all"]').change(function() {
+
+        $('input.search_filter_all').change(function() {
             var all_checked = this.checked;
-            sfu.find('input[name="limit_users"]').each(function() {
+            $(this).parent().find('input.search_filter_item').each(function() {
                 this.checked = all_checked;
             });
         });
 
-        sfu.find('input[name="limit_users"]').change(function() {
+        $('input.search_filter_item').change(function() {
             var all_checked = true;
-            sfu.find('input[name="limit_users"]').each(function() {
+            var parent = $(this).parent().parent()
+            parent.find('input.search_filter_item').each(function() {
                 all_checked = all_checked && this.checked;
             });
-            $('input[name="limit_users_all"]').prop('checked', all_checked);
+            parent.find('input.search_filter_all').prop('checked', all_checked);
         });
+
 
         $(".search_filter_toggle").click(function(event){
             event.preventDefault();
@@ -164,17 +166,18 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         <div id="search_filter_users">
             <label for="limit_users">Filter by users:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
-            <div style="margin-left:20px" class="search_filter_selector">
-                <input type="checkbox" checked="true" name="limit_users_all" value="All">All</input>
-                <div>
-                    {% for userid, username in users.items %}
-                        <div style="margin-left:20px">
-                            <input type="checkbox" checked="checked"
-                                name="limit_users" value="{{userid}}"
-                                >{{ username }}</input>
-                        </div>
-                    {% endfor %}
+            <div style="margin-left:20px">
+                <input type="checkbox" checked="true" name="limit_users_all"
+                    class="search_filter_all" value="All">All</input>
+
+                {% for userid, username in users.items %}
+                <div style="margin-left:20px">
+                    <input type="checkbox" checked="checked"
+                        class="search_filter_item"
+                        name="limit_users" value="{{userid}}"
+                        >{{ username }}</input>
                 </div>
+                {% endfor %}
             </div>
         </div>
 

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -200,17 +200,17 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         </div>
 
         <div id="search_filter_users">
-            <label for="limit_channels">Filter by channels:</label>
+            <label for="limit_channelidxs">Filter by channel index:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
-                <input type="checkbox" checked="true" name="limit_channels_all"
+                <input type="checkbox" checked="true" name="limit_channelidxs_all"
                     class="search_filter_all" value="All">All</input>
 
-                {% for chid, chname in channels.items %}
+                {% for chid, chname in channelidxs.items %}
                 <div style="margin-left:20px">
                     <input type="checkbox" checked="checked"
                         class="search_filter_item"
-                        name="limit_channels" value="{{chid}}"
+                        name="limit_channelidxs" value="{{chid}}"
                         >{{ chname }}</input>
                 </div>
                 {% endfor %}

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -203,6 +203,20 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                 </div>
                 {% endfor %}
 
+                <div>
+                    <input type="checkbox" checked="checked"
+                        class="search_filter_all" name="project"
+                        value="[No project]">[No project]</input>
+
+                    {% for dsid, dsname in datasets.items %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox" checked="checked"
+                            class="search_filter_item" name="limit_datasets"
+                            value="{{dsid}}">{{ dsname }}</input>
+                    </div>
+                    {% endfor %}
+                </div>
+
             </div>
         </div>
 

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -66,20 +66,21 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         });
 
 
-        $('input.search_filter_all').change(function() {
-            var all_checked = this.checked;
-            $(this).parent().find('input.search_filter_item').each(function() {
-                this.checked = all_checked;
-            });
-        });
-
         $('input.search_filter_item').change(function() {
             var all_checked = true;
             var parent = $(this).parent().parent()
-            parent.find('input.search_filter_item').each(function() {
+            parent.children().children('input.search_filter_item').each(function() {
                 all_checked = all_checked && this.checked;
             });
             parent.find('input.search_filter_all').prop('checked', all_checked);
+        });
+
+        $('input.search_filter_all').change(function() {
+            var all_checked = this.checked;
+            $(this).parent().children().children('input.search_filter_item')
+                .each(function() {
+                    this.checked = all_checked;
+                });
         });
 
 
@@ -178,6 +179,30 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                         >{{ username }}</input>
                 </div>
                 {% endfor %}
+            </div>
+        </div>
+
+        <div id="search_filter_datasets">
+            <label for="limit_datasets">Filter by Project/Dataset:</label>
+            <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
+            <div style="margin-left:20px">
+
+                {% for projectid, projectdata in projects.items %}
+                <div>
+                    <input type="checkbox" checked="checked"
+                        class="search_filter_all" name="project"
+                        value="{{projectdata.0}}">{{projectdata.0}}</input>
+
+                    {% for dsid, dsname in projectdata.1.items %}
+                    <div style="margin-left:20px">
+                        <input type="checkbox" checked="checked"
+                            class="search_filter_item" name="limit_datasets"
+                            value="{{dsid}}">{{ dsname }}</input>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+
             </div>
         </div>
 

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -199,6 +199,24 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
+        <div id="search_filter_users">
+            <label for="limit_channels">Filter by channels:</label>
+            <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
+            <div style="margin-left:20px">
+                <input type="checkbox" checked="true" name="limit_channels_all"
+                    class="search_filter_all" value="All">All</input>
+
+                {% for chid, chname in channels.items %}
+                <div style="margin-left:20px">
+                    <input type="checkbox" checked="checked"
+                        class="search_filter_item"
+                        name="limit_channels" value="{{chid}}"
+                        >{{ chname }}</input>
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+
         <input style="float:right" type="submit" value="Do Search"/> 
 
         <div style="clear:both"></div>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -143,27 +143,6 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </select>
         </div>
 
-        <div>
-            <label for="search_against">Search Against:</label>
-            <div style="margin-left:20px">
-                <div style="float:left">
-                    Entire Database<input type="radio" checked='true' name="search_against" value="db"/>
-                </div>
-                <div style="float:left">
-                    Dataset<input type="radio" name="search_against" value="dataset"/><br/>
-                    <select name="dataset_ID" disabled="true">
-                        {% for d in datasets %}
-                            <option value="{{ d.getId }}">
-                                {{ d.getName }}
-                                {% if d.countChildren %} [{{ d.countChildren }}] {% endif %}
-                            </option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div style="clear:both"></div>
-            </div>
-        </div>
-
         <div id="search_filter_users">
             <label for="limit_users">Filter by users:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -150,12 +150,12 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                 <input type="checkbox" checked="true" name="limit_users_all"
                     class="search_filter_all" value="All">All</input>
 
-                {% for userid, username in users.items %}
+                {% for user in users %}
                 <div style="margin-left:20px">
                     <input type="checkbox" checked="checked"
                         class="search_filter_item"
-                        name="limit_users" value="{{userid}}"
-                        >{{ username }}</input>
+                        name="limit_users" value="{{user.0}}"
+                        >{{ user.1 }}</input>
                 </div>
                 {% endfor %}
             </div>
@@ -166,17 +166,17 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
 
-                {% for projectid, projectdata in projects.items %}
+                {% for proj in projects %}
                 <div>
                     <input type="checkbox" checked="checked"
                         class="search_filter_all" name="project"
-                        value="{{projectdata.0}}">{{projectdata.0}}</input>
+                        value="{{proj.0}}">{{proj.1}}</input>
 
-                    {% for dsid, dsname in projectdata.1.items %}
+                    {% for dset in proj.2 %}
                     <div style="margin-left:20px">
                         <input type="checkbox" checked="checked"
                             class="search_filter_item" name="limit_datasets"
-                            value="{{dsid}}">{{ dsname }}</input>
+                            value="{{dset.0}}">{{ dset.1 }}</input>
                     </div>
                     {% endfor %}
                 </div>
@@ -187,11 +187,11 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                         class="search_filter_all" name="project"
                         value="[No project]">[No project]</input>
 
-                    {% for dsid, dsname in datasets.items %}
+                    {% for dset in datasets %}
                     <div style="margin-left:20px">
                         <input type="checkbox" checked="checked"
                             class="search_filter_item" name="limit_datasets"
-                            value="{{dsid}}">{{ dsname }}</input>
+                            value="{{dset.0}}">{{ dset.1 }}</input>
                     </div>
                     {% endfor %}
                 </div>
@@ -206,12 +206,12 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                 <input type="checkbox" checked="true" name="limit_channelidxs_all"
                     class="search_filter_all" value="All">All</input>
 
-                {% for chid, chname in channelidxs.items %}
+                {% for ch in channelidxs %}
                 <div style="margin-left:20px">
                     <input type="checkbox" checked="checked"
                         class="search_filter_item"
-                        name="limit_channelidxs" value="{{chid}}"
-                        >{{ chname }}</input>
+                        name="limit_channelidxs" value="{{ch.0}}"
+                        >{{ ch.1 }}</input>
                 </div>
                 {% endfor %}
             </div>

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -144,7 +144,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         </div>
 
         <div id="search_filter_users">
-            <label for="limit_users">Filter by users:</label>
+            <label for="limit_users">Filter by user:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
                 <input type="checkbox" checked="true" name="limit_users_all"
@@ -162,7 +162,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         </div>
 
         <div id="search_filter_datasets">
-            <label for="limit_datasets">Filter by Project/Dataset:</label>
+            <label for="limit_datasets">Filter by project/dataset:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
 
@@ -199,7 +199,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
-        <div id="search_filter_users">
+        <div id="search_filter_channelidxs">
             <label for="limit_channelidxs">Filter by channel index:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -97,6 +97,16 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             $(this).prev().text('[+] show');
         });
 
+        $("#enable_search_filters").change(function() {
+            if (this.checked) {
+                $(".search_filter_group").slideDown();
+            }
+            else {
+                $(".search_filter_group").slideUp();
+            }
+        });
+        $(".search_filter_group").hide();
+
     });    
 
 </script>
@@ -143,7 +153,13 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </select>
         </div>
 
-        <div id="search_filter_users">
+        <div>
+            <input type="checkbox" id="enable_search_filters"
+                name="enable_filters" value="enable">Enable
+                additional search filters (may slow down queries).</input>
+        </div>
+
+        <div class="search_filter_group">
             <label for="limit_users">Filter by user:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
@@ -161,7 +177,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
-        <div id="search_filter_datasets">
+        <div class="search_filter_group">
             <label for="limit_datasets">Filter by project/dataset:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
@@ -199,7 +215,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
-        <div id="search_filter_channelidxs">
+        <div class="search_filter_group">
             <label for="limit_channelidxs">Filter by channel index:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">
@@ -217,7 +233,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
             </div>
         </div>
 
-        <div id="search_filter_channelnames">
+        <div class="search_filter_group">
             <label for="limit_channelnames">Filter by channel name:</label>
             <a href="#" title="Show/Hide" class="search_filter_toggle"></a>
             <div style="margin-left:20px">

--- a/views.py
+++ b/views.py
@@ -128,7 +128,7 @@ def getImageDatasetMap(conn):
     return imDsMap
 
 
-def getAvailableChannels(conn):
+def getChannelIndices(conn):
     """
     Hard code now, to save having to load the ContentDB
     TODO: Figure out how to get a useful list of available channels
@@ -225,8 +225,7 @@ def right_plugin_search_form (request, conn=None, **kwargs):
     context['projects'] = projects
     context['datasets'] = orphanDatasets
 
-    # Note: List of channels is currently hardcoded
-    context['channels'] = getAvailableChannels(conn)
+    context['channelidxs'] = getChannelIndices(conn)
 
     logger.debug('Context:%s', context)
     return context
@@ -259,9 +258,9 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
     limit_datasets = [int(x) for x in limit_datasets]
     context['limit_datasets'] = limit_datasets
 
-    limit_channels = request.POST.getlist("limit_channels")
-    limit_channels = [int(x) for x in limit_channels]
-    context['limit_channels'] = limit_channels
+    limit_channelidxs = request.POST.getlist("limit_channelidxs")
+    limit_channelidxs = [int(x) for x in limit_channelidxs]
+    context['limit_channelidxs'] = limit_channelidxs
 
     users = getGroupMembers(conn, request)
     context['users'] = users
@@ -270,7 +269,7 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
     context['projects'] = projects
     context['datasets'] = orphanDatasets
 
-    context['channels'] = getAvailableChannels(conn)
+    context['channelidxs'] = getChannelIndices(conn)
 
     superIds = request.POST.getlist("superIds")
     if superIds:
@@ -343,16 +342,16 @@ def contentsearch( request, conn=None, **kwargs):
     # TODO: Optimise, this is slow
     imDsMap = getImageDatasetMap(conn)
 
-    limit_channels = request.POST.getlist("limit_channels")
-    if len(limit_channels) == 0:
+    limit_channelidxs = request.POST.getlist("limit_channelidxs")
+    if len(limit_channelidxs) == 0:
         context = {
             'template': 'searcher/contentsearch/search_error.html',
-            'message': 'No channels selected'
+            'message': 'No channel indices selected'
             }
         return context
 
-    limit_channels = set(int(x) for x in limit_channels)
-    logger.debug('Got limit_channels: %s', limit_channels)
+    limit_channelidxs = set(int(x) for x in limit_channelidxs)
+    logger.debug('Got limit_channelidxs: %s', limit_channelidxs)
 
 
     superIds = request.POST.getlist("superIds")
@@ -452,7 +451,7 @@ def contentsearch( request, conn=None, **kwargs):
         reference image even if it doesn't fit the criteria.
         E.g. Reference channel 1 against query channel 2.
         """
-        return int(im_id.split('.')[2]) in limit_channels
+        return int(im_id.split('.')[2]) in limit_channelidxs
 
     im_ids_sorted = [sid for sid in im_ids_sorted if filter_superid(sid)]
     logger.debug('Filtered im_ids_sorted:%s', im_ids_sorted)

--- a/views.py
+++ b/views.py
@@ -83,7 +83,7 @@ def getIdCztPnFromImageIds(imageIds, reqvars):
     return idCztPn
 
 
-def getGroupMembers(conn, request):
+def getGroupMembers(conn):
     """
     Get a list of user-ids and names
     """
@@ -225,7 +225,7 @@ def right_plugin_search_form (request, conn=None, **kwargs):
 
     context['images'] = images
 
-    users = getGroupMembers(conn, request)
+    users = getGroupMembers(conn)
     context['users'] = users
 
     projects, orphanDatasets = getProjectsDatasets(conn)
@@ -269,7 +269,7 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
     limit_channelidxs = [int(x) for x in limit_channelidxs]
     context['limit_channelidxs'] = limit_channelidxs
 
-    users = getGroupMembers(conn, request)
+    users = getGroupMembers(conn)
     context['users'] = users
 
     projects, orphanDatasets = getProjectsDatasets(conn)

--- a/views.py
+++ b/views.py
@@ -407,6 +407,12 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
         idCztPn = getIdCztPnFromImageIds(allIds, request.POST)
         imageIds = idCztPn.keys()
 
+    if not imageIds:
+        # This usually occurs if someone attempts to load one of the internal
+        # OMERO.searcher pages without GET/POST variables.
+        logger.error('No imageIds')
+        return {'template': 'searcher/index.html'}
+
     images = []
     for i in conn.getObjects("Image", imageIds):
         available = listAvailableCZTS(conn, i.id, str(context['fset']))

--- a/views.py
+++ b/views.py
@@ -11,6 +11,7 @@
 
 import logging
 from collections import defaultdict
+from datetime import datetime
 from operator import itemgetter
 
 from omeroweb.webclient.decorators import login_required, render_response
@@ -425,6 +426,7 @@ def searchpage( request, iIds=None, dId = None, fset = None, numret = None, negI
 @login_required(setGroupContext=True)
 @render_response()
 def contentsearch( request, conn=None, **kwargs):
+    startTime = datetime.now()
 
     #server_name=request.META['SERVER_NAME']
     #owner=request.session['username']
@@ -687,6 +689,11 @@ def contentsearch( request, conn=None, **kwargs):
 
     context['images'] = images
     #logger.debug('context images:%s', images)
+
+    endTime = datetime.now()
+    dd = endTime - startTime
+    context['performance'] = '%d results returned in %d.%d seconds' % (
+        len(images), dd.seconds, dd.microseconds)
 
     return context
 

--- a/views.py
+++ b/views.py
@@ -452,7 +452,7 @@ def contentsearch( request, conn=None, **kwargs):
     logger.debug('Got enable_filters: %s', enable_filters)
 
     limit_users = request.POST.getlist("limit_users")
-    if len(limit_users) == 0:
+    if enable_filters and len(limit_users) == 0:
         context = {
             'template': 'searcher/contentsearch/search_error.html',
             'message': 'No users selected'
@@ -463,7 +463,7 @@ def contentsearch( request, conn=None, **kwargs):
     logger.debug('Got limit_users: %s', limit_users)
 
     limit_datasets = request.POST.getlist("limit_datasets")
-    if len(limit_datasets) == 0:
+    if enable_filters and len(limit_datasets) == 0:
         context = {
             'template': 'searcher/contentsearch/search_error.html',
             'message': 'No datasets selected'
@@ -474,7 +474,7 @@ def contentsearch( request, conn=None, **kwargs):
     logger.debug('Got limit_datasets: %s', limit_datasets)
 
     limit_channelidxs = request.POST.getlist("limit_channelidxs")
-    if len(limit_channelidxs) == 0:
+    if enable_filters and len(limit_channelidxs) == 0:
         context = {
             'template': 'searcher/contentsearch/search_error.html',
             'message': 'No channel indices selected'
@@ -485,7 +485,7 @@ def contentsearch( request, conn=None, **kwargs):
     logger.debug('Got limit_channelidxs: %s', limit_channelidxs)
 
     limit_channelnames = request.POST.getlist("limit_channelnames")
-    if len(limit_channelnames) == 0:
+    if enable_filters and len(limit_channelnames) == 0:
         context = {
             'template': 'searcher/contentsearch/search_error.html',
             'message': 'No channel names selected'

--- a/views.py
+++ b/views.py
@@ -723,8 +723,8 @@ def contentsearch( request, conn=None, **kwargs):
 
     endTime = datetime.now()
     dd = endTime - startTime
-    context['performance'] = '%d results returned in %d.%d seconds' % (
-        len(images), dd.seconds, dd.microseconds)
+    context['performance'] = '%d results returned in %d.%03d seconds' % (
+        len(images), dd.seconds, dd.microseconds / 1000)
 
     return context
 

--- a/views.py
+++ b/views.py
@@ -514,6 +514,15 @@ def contentsearch( request, conn=None, **kwargs):
                 'czt': czt})
         if ranki == numret:
             break
+
+    if len(images) == 0:
+        context = {'template':
+                       'searcher/contentsearch/search_error.html'}
+        context['message'] = (
+            'No results found. Please try widening your search parameters, '
+            'or calculating features for more images.')
+        return context
+
     context['images'] = images
     #logger.debug('contentsearch images:%s', images)
 

--- a/views.py
+++ b/views.py
@@ -174,10 +174,6 @@ def right_plugin_search_form (request, conn=None, **kwargs):
     """
     context = {'template': 'searcher/right_plugin_search_form.html'}
 
-    datasets = list(conn.getObjects("Dataset"))
-    datasets.sort(key=lambda x: x.getName() and x.getName().lower())
-    context['datasets'] = datasets
-
     images = []
 
     superIds = request.REQUEST.getlist('imagesuperid')


### PR DESCRIPTION
Added more options for filtering results in addition to by user. This includes:
- Filter by channel index
- Filter by channel name
- Filter by dataset

Note all filters must be explicitly enabled by clicking the checkbox, this is because they may take an excessively long time since the ContentDB has to be cross-referenced with the OMERO database [Trac 11144](https://trac.openmicroscopy.org.uk/ome/ticket/11144).

Also some UI changes, including
- Loading indicator when the submit/search button is clicked
- Performance indicator: `[NN] results returned in [TT] seconds` at the bottom of the central pane [Trac 11143](https://trac.openmicroscopy.org.uk/ome/ticket/11143)
- Slightly nicer error message when someone ends up at an internal OMERO.searcher page without any GET/POST variables [Trac 11057](https://trac.openmicroscopy.org.uk/ome/ticket/11057)
