### PR TITLE
Installation script trac 11199

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# Install OMERO.searcher, retaining the previous configuration file if found
+#
+
+# Abort on error
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "USAGE: `basename $0` /path/to/omero/server/"
+    exit 2
+fi
+
+OMERO_SERVER="$1"
+SCRIPT_DEST="$OMERO_SERVER/lib/scripts/searcher"
+WEB_DEST="$OMERO_SERVER/lib/python/omeroweb/omero_searcher"
+CONFIG="$WEB_DEST/omero_searcher_config.py"
+
+if [ -e "$CONFIG" ]; then
+    OLD_CONFIG=`mktemp -t omero_searcher_config`
+    cat "$CONFIG" >> "$OLD_CONFIG"
+fi
+
+if [ -e "$SCRIPT_DEST" -o -e "$WEB_DEST" ]; then
+    echo "Deleting $SCRIPT_DEST and/or $WEB_DEST in 5s, hit Ctrl-C to abort"
+    sleep 5
+    rm -rf "$SCRIPT_DEST" "$WEB_DEST"
+fi
+
+mkdir "$SCRIPT_DEST"
+cp -a scripts/* "$SCRIPT_DEST"
+
+mkdir "$WEB_DEST"
+cp -a *.py templates "$WEB_DEST"
+
+if [ -n "$OLD_CONFIG" ]; then
+    echo "Copying previous configuration"
+    mv "$OLD_CONFIG" "$CONFIG"
+fi
+
+OMERO="$OMERO_SERVER/bin/omero"
+CONFIG_KEY=`"$OMERO" config get omero.web.apps`
+if [ -z "$CONFIG_KEY" ]; then
+    "$OMERO" config set omero.web.apps "[\"omero_searcher\"]"
+else
+    # TODO: Automatically append omero_searcher to the omero.web.apps config key
+    # (requires parsing the existing value of omero.web.apps if any)
+    echo "omero.web.apps configuration key is non-empty."
+    echo "Please enable OMERO.searcher manually by running :"
+    echo "    omero config set omero.web.apps '[..., \"omero_searcher\"]'"
+fi
+

--- a/install.sh
+++ b/install.sh
@@ -1,55 +1,118 @@
 #!/bin/sh
-#
-# Install OMERO.searcher, retaining the previous configuration file if found
-#
 
 # Abort on error
 set -e
 
-if [ $# -ne 1 ]; then
+cat <<EOF
+OMERO.searcher installation script
+==================================
+
+Installs OMERO.searcher, retains the previous configuration file if
+found.
+
+This script will attempt to install several Python dependencies. It
+is highly recommended that you first create and activate a Python
+virtualenv.
+
+The Python mahotas module requires the freeimage library to be
+installed in advance. On CentOS this is available from the EPEL
+repository:
+    yum install freeimage
+On Mac OS X it can be installed using homebrew:
+    brew install freeimage
+
+EOF
+
+usage() {
     echo "USAGE: `basename $0` /path/to/omero/server/"
-    exit 2
+    exit $1
+}
+
+if [ $# -eq 0 -o "$1" = "-h" ]; then
+    usage 0
 fi
+
+if [ $# -ne 1 ]; then
+    echo "Unexpected arguments"
+    usage 2
+fi
+
+if [ ! -d "$1" ]; then
+    echo "Invalid server directory: $1"
+    usage 2
+fi
+
 
 OMERO_SERVER="$1"
 SCRIPT_DEST="$OMERO_SERVER/lib/scripts/searcher"
 WEB_DEST="$OMERO_SERVER/lib/python/omeroweb/omero_searcher"
 CONFIG="$WEB_DEST/omero_searcher_config.py"
 
+echo "Installing python dependencies"
+pip install -r requirements.txt
+
 if [ -e "$CONFIG" ]; then
+    echo "Saving old configuration"
     OLD_CONFIG=`mktemp -t omero_searcher_config`
     cat "$CONFIG" >> "$OLD_CONFIG"
 fi
 
 if [ -e "$SCRIPT_DEST" -o -e "$WEB_DEST" ]; then
+    echo
+    echo "***** WARNING *****"
     echo "Deleting $SCRIPT_DEST and/or $WEB_DEST in 5s, hit Ctrl-C to abort"
     sleep 5
     rm -rf "$SCRIPT_DEST" "$WEB_DEST"
 fi
 
+echo "Installing scripts"
 mkdir "$SCRIPT_DEST"
 cp -a scripts/* "$SCRIPT_DEST"
 
+echo "Installing web-app"
 mkdir "$WEB_DEST"
 cp -a *.py templates "$WEB_DEST"
 
 if [ -n "$OLD_CONFIG" ]; then
-    echo "Copying previous configuration"
+    echo "Restoring previous configuration"
     mv "$OLD_CONFIG" "$CONFIG"
 fi
 
+echo "Configuring OMERO web-apps"
 OMERO="$OMERO_SERVER/bin/omero"
+
+# Disable exit on failure so that we can print out a more informative message
+set +e
 CONFIG_KEY=`"$OMERO" config get omero.web.apps`
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to run $OMERO config"
+    exit 2
+fi
+
 if [ -z "$CONFIG_KEY" ]; then
     "$OMERO" config set omero.web.apps "[\"omero_searcher\"]"
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to run $OMERO config"
+        exit 2
+    fi
 else
     # TODO: Automatically append omero_searcher to the omero.web.apps config key
     # (requires parsing the existing value of omero.web.apps if any)
-    echo "omero.web.apps configuration key is non-empty."
-    echo "Please enable OMERO.searcher manually by running :"
-    echo "    omero config set omero.web.apps '[..., \"omero_searcher\"]'"
+cat <<EOF
+
+***** WARNING *****
+OMERO web-apps configuration failed.
+The omero.web.apps configuration key is non-empty. Please enable
+OMERO.searcher manually by running something like:
+    omero config set omero.web.apps '[..., \"omero_searcher\"]'"
+
+EOF
 fi
 
-echo "If this is a new installation you must create the OMERO.searcher data"
-echo "directory, see $CONFIG"
+if [ -z "$OLD_CONFIG" ]; then
+cat <<EOF
+If this is a new installation you must create the OMERO.searcher data
+directory, see $CONFIG
 
+EOF
+fi

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ pip install -r requirements.txt
 
 if [ -e "$CONFIG" ]; then
     echo "Saving old configuration"
-    OLD_CONFIG=`mktemp -t omero_searcher_config`
+    OLD_CONFIG=`mktemp -t omero_searcher_config.XXXXXX`
     cat "$CONFIG" >> "$OLD_CONFIG"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -50,3 +50,6 @@ else
     echo "    omero config set omero.web.apps '[..., \"omero_searcher\"]'"
 fi
 
+echo "If this is a new installation you must create the OMERO.searcher data"
+echo "directory, see $CONFIG"
+

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,8 @@ On Mac OS X it can be installed using homebrew:
 EOF
 
 usage() {
-    echo "USAGE: `basename $0` /path/to/omero/server/"
+    echo "USAGE: `basename $0` OMERO_PREFIX"
+    echo "  OMERO_PREFIX: The root directory of the OMERO server installation"
     exit $1
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 # which requires the freeimage library.
 
 # This contains several changes not present in the upstream PySLID module
-git+git://github.com/manics/pyslid.git@add_tests_exceptions_tweaks
+git+git://github.com/manics/pyslid.git@merge_all
+
 
 git+git://github.com/icaoberg/ricerca.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,18 @@
+# Note: You might prefer to install the distribution supplied versions
+# of numpy and scipy instead of using pip
+numpy
+scipy
+
+# Note: mahotas requires the freeimage library
+mahotas==0.9.4
+
+milk==0.4.3
+
+pymorph==0.96
+
+pyslic==0.6.1
+
+# This contains several changes not present in the upstream PySLID module
+git+git://github.com/manics/pyslid.git@add_tests_exceptions_tweaks
+
+git+git://github.com/icaoberg/ricerca.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,10 @@
 # Note: You might prefer to install the distribution supplied versions
 # of numpy and scipy instead of using pip
-numpy
-scipy
+#numpy
+#scipy
 
-# Note: mahotas requires the freeimage library
-mahotas==0.9.4
-
-milk==0.4.3
-
-pymorph==0.96
-
-pyslic==0.6.1
+# Note: PySLID has several additional dependencies, including mahotas
+# which requires the freeimage library.
 
 # This contains several changes not present in the upstream PySLID module
 git+git://github.com/manics/pyslid.git@add_tests_exceptions_tweaks


### PR DESCRIPTION
Download/clone the omero_searcher repo somewhere. Enter the directory, run `./install.sh` to see a help message.

Run `./install.sh /path/to/omero/server` to install OMERO.searcher. This will also attempt to install the Python dependencies using pip, however there is also a dependency on the `freeimage` library which can't be installed automatically. For your sanity you might want to create a virtualenv first.

This script also attempts to configure the `omero.web.apps` config value, however it does not create the OMERO.searcher/PySLID data directory- you must do this manually.
