### PR TITLE
Allow the list of feature sets in the UI to be configurable

### DIFF
--- a/omero_searcher_config.py
+++ b/omero_searcher_config.py
@@ -4,4 +4,6 @@
 # Path to the directory for storing ContentDB files
 omero_contentdb_path = '/OMERO/pyslid.data'
 
+# List of feature sets to display in the UI, the first will be the default
+enabled_featuresets = ['slf33', 'slf34']
 

--- a/scripts/Omero_Searcher_Delete_Feature_Tables.py
+++ b/scripts/Omero_Searcher_Delete_Feature_Tables.py
@@ -8,6 +8,7 @@ import sys
 
 import pyslid
 from omeroweb.omero_searcher.omero_searcher_config import omero_contentdb_path
+from omeroweb.omero_searcher.omero_searcher_config import enabled_featuresets
 pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 
 
@@ -139,8 +140,8 @@ def runScript():
 
         scripts.String('Feature_set', optional=False, grouping='1',
                        description='SLF set',
-                       values=[rstring('slf33'), rstring('slf34')],
-                       default='slf33'),
+                       values=[rstring(f) for f in enabled_featuresets],
+                       default=enabled_featuresets[0]),
 
         version = '0.0.1',
         authors = ['Marvin the Paranoid Android'],

--- a/scripts/Omero_Searcher_Feature_Calculation.py
+++ b/scripts/Omero_Searcher_Feature_Calculation.py
@@ -8,6 +8,7 @@ import sys
 
 import pyslid
 from omeroweb.omero_searcher.omero_searcher_config import omero_contentdb_path
+from omeroweb.omero_searcher.omero_searcher_config import enabled_featuresets
 pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 
 
@@ -149,8 +150,6 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
             return message + m
         readoutCh = [channels[1] - IDX_OFFSET]
 
-    if ftset == 'slf33':
-        otherChs = []
     if ftset == 'slf34':
         if (channels[2] < IDX_OFFSET or
             channels[2] >= image.getSizeC() + IDX_OFFSET):
@@ -158,6 +157,8 @@ def extractFeatures(conn, image, scale, ftset, scaleSet,
             sys.stderr.write(m)
             return message + m
         otherChs = [channels[2] - IDX_OFFSET]
+    else:
+        otherChs = []
 
     for c in readoutCh:
         chs = [c] + otherChs
@@ -280,8 +281,8 @@ def runScript():
 
         scripts.String('Feature_set', optional=False, grouping='2',
                        description='SLF set',
-                       values=[rstring('slf33'), rstring('slf34')],
-                       default='slf33'),
+                       values=[rstring(f) for f in enabled_featuresets],
+                       default=enabled_featuresets[0]),
 
         scripts.Bool(
             'Select_Readout_Channel_instead_of_all',

--- a/scripts/Omero_Searcher_Rebuild_ContentDB.py
+++ b/scripts/Omero_Searcher_Rebuild_ContentDB.py
@@ -6,6 +6,7 @@ import sys
 
 import pyslid
 from omeroweb.omero_searcher.omero_searcher_config import omero_contentdb_path
+from omeroweb.omero_searcher.omero_searcher_config import enabled_featuresets
 pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 
 
@@ -165,8 +166,8 @@ def runScript():
 
         scripts.String('Feature_set', optional=False, grouping='1',
                        description='SLF set',
-                       values=[rstring('slf33'), rstring('slf34')],
-                       default='slf33'),
+                       values=[rstring(f) for f in enabled_featuresets],
+                       default=enabled_featuresets[0]),
 
         version = '0.0.1',
         authors = ['Marvin the Paranoid Android'],

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -148,8 +148,9 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
         <div>
             <label>Featureset Name:
                 <select id="featureset" name="featureset_Name">
-                    <option value="slf33">slf33</option>
-                    <option value="slf34">slf34</option>
+                    {% for ftset in featuresets %}
+                    <option value="{{ ftset }}">{{ ftset }}</option>
+                    {% endfor %}
                 </select>
             </label>
         </div>

--- a/views.py
+++ b/views.py
@@ -31,6 +31,7 @@ logger = logging.getLogger('searcher')
 
 import pyslid
 from omero_searcher_config import omero_contentdb_path
+from omero_searcher_config import enabled_featuresets
 pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 import ricerca
 
@@ -312,7 +313,11 @@ def right_plugin_search_form (request, conn=None, **kwargs):
     This generates a search form in the right panel with the currently selected images, allowing
     a user to initialize a content search.
     """
-    context = {'template': 'searcher/right_plugin_search_form.html'}
+
+    context = {
+        'featuresets': enabled_featuresets,
+        'template': 'searcher/right_plugin_search_form.html'
+        }
 
     images = []
 


### PR DESCRIPTION
The list of featuresets displayed in rthe OMERO.searcher UI can now be configured in `omero_searcher_config.py`. This means you can enable a very simple feature set, `min_max_mean`, for testing/debugging purposes (note this requires https://github.com/icaoberg/pyslid/pull/14).
