### PR TITLE
Django urls and other OMERO5 fixes

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -5,13 +5,12 @@ from django.conf import settings
 
 # We can directly manipulate the settings
 # E.g. add plugins to RIGHT_PLUGINS list
-try:
-    # OMERO 4.4
+import django
+if django.VERSION < (1, 6):
     settings.RIGHT_PLUGINS.append([
             "Searcher",
             "searcher/plugin_config/right_search_form.js.html",
             "right_search_form"])
-except AttributeError:
-    # OMERO 5: Need to manually configure:
-    # omero config set omero.ui.right_plugins '[[...], ... ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'
-    pass
+
+# OMERO 5: Need to manually configure:
+# omero config set omero.ui.right_plugins '[[...], ... ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'

--- a/settings.py
+++ b/settings.py
@@ -5,5 +5,13 @@ from django.conf import settings
 
 # We can directly manipulate the settings
 # E.g. add plugins to RIGHT_PLUGINS list
-settings.RIGHT_PLUGINS.append(["Searcher",
-    "searcher/plugin_config/right_search_form.js.html", "right_search_form"])
+try:
+    # OMERO 4.4
+    settings.RIGHT_PLUGINS.append([
+            "Searcher",
+            "searcher/plugin_config/right_search_form.js.html",
+            "right_search_form"])
+except AttributeError:
+    # OMERO 5: Need to manually configure:
+    # omero config set omero.ui.right_plugins '[[...], ... ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'
+    pass

--- a/settings.py
+++ b/settings.py
@@ -2,15 +2,3 @@ from django.conf import settings
 
 # This settings.py file will be imported AFTER settings
 # have been initialised in omeroweb/settings.py
-
-# We can directly manipulate the settings
-# E.g. add plugins to RIGHT_PLUGINS list
-import django
-if django.VERSION < (1, 6):
-    settings.RIGHT_PLUGINS.append([
-            "Searcher",
-            "searcher/plugin_config/right_search_form.js.html",
-            "right_search_form"])
-
-# OMERO 5: Need to manually configure:
-# omero config set omero.ui.right_plugins '[[...], ... ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -1,4 +1,5 @@
 {% extends "webclient/search/search.html" %}
+{% load url from future %}
 {% load i18n %}
 
 {% block script %}
@@ -150,7 +151,8 @@
     <h1>{% trans "Search again with additional image(s)" %}</h1>
 
 
-    <form id="content_search" class="content_search" method="POST" action="{% url contentsearch %}">
+    <form id="content_search" class="content_search" method="POST"
+        action="{% url 'contentsearch' %}">
 
         <div>
             <label>Feature-set:
@@ -322,7 +324,7 @@
                 {% for c in images %}
                     <tr>
                         <td class="action">
-                            <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
+                            <img src="{% url 'render_thumbnail_resize' 32 c.id  %}" alt="image" title="{{c.id}}"/>
                             <input name="superIds" style="display:none" value="{{c.superid}}" type="text" />
 
                         </td>
@@ -346,7 +348,7 @@
     <hr style="clear:both"/>
 
     <form id="export_search" class="content_search" method="POST"
-        action="{% url exportsearch %}">
+        action="{% url 'exportsearch' %}">
         <label for="doExport">
             Export the most recent search results to a CSV file
         </label>

--- a/templates/searcher/contentsearch/searchresult.html
+++ b/templates/searcher/contentsearch/searchresult.html
@@ -1,4 +1,5 @@
 {% extends "webclient/search/search_details.html" %}
+{% load url from future %}
 {% load i18n %}
 {% load common_filters %}
 
@@ -24,7 +25,7 @@
                 {% for c in images %}
                     <tr id="image-{{ c.id }}-{{ c.superid }}" class="{{ c.getPermsCss }}">
                         <td class="action">
-                            <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
+                            <img src="{% url 'render_thumbnail_resize' 32 c.id  %}" alt="image" title="{{c.id}}"/>
                             <input name="superIds" style="display:none" value="{{ c.superid }}" type="text" />
 
                         </td>

--- a/templates/searcher/index.html
+++ b/templates/searcher/index.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
@@ -7,7 +8,7 @@
 <body>
 <h1>OMERO.searcher</h1>
 
-<p>Error: you shouldn't have reached this page directly. Please return to <a href="{% url index %}">OMERO.web</a> to use OMERO.searcher.</p>
+<p>Error: you shouldn't have reached this page directly. Please return to <a href="{% url 'index' %}">OMERO.web</a> to use OMERO.searcher.</p>
 
 </body> 
 </html>

--- a/templates/searcher/plugin_config/right_search_form.js.html
+++ b/templates/searcher/plugin_config/right_search_form.js.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 <script>
 
 $(document).ready(function() {
@@ -19,7 +20,7 @@ $(document).ready(function() {
                 }
             }
             queryString = imageIds.join("&");
-            $(this).load('{% url right_plugin_search_form %}?' + queryString);
+            $(this).load('{% url 'right_plugin_search_form' %}?' + queryString);
         },
         //supported_obj_types: ['image','dataset'],   // E.g. only support single image/dataset selected
         

--- a/templates/searcher/right_plugin_search_form.html
+++ b/templates/searcher/right_plugin_search_form.html
@@ -1,3 +1,4 @@
+{% load url from future %}
 
 {% load i18n %}
 {% load common_filters %}
@@ -144,7 +145,7 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
 
     <h1>Image Content Search</h1>
 
-    <form class="content_search" method="POST" action="{% url searchpage %}">
+    <form class="content_search" method="POST" action="{% url 'searchpage' %}">
         <div>
             <label>Featureset Name:
                 <select id="featureset" name="featureset_Name">
@@ -317,7 +318,8 @@ Authors: Baek Hwan Cho and Robert F. Murphy @CMU
                 {% for c in images %}
                     <tr>
                         <td class="action">
-                            <img src="{% url render_thumbnail_resize 32 c.id  %}" alt="image" title="{{c.id}}"/>
+                            <img src="{% url 'render_thumbnail_resize' 32 c.id  %}"
+                                alt="image" title="{{c.id}}"/>
                             <input name="allIds" style="display:none" value="{{c.superid}}" type="text" />
 
                         </td>

--- a/urls.py
+++ b/urls.py
@@ -10,10 +10,10 @@
 #
 import os.path
 
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 from django.views.static import serve
 
-from omeroweb.omero_searcher import views
+from . import views
 
 urlpatterns = patterns('django.views.generic.simple',
 

--- a/urls.py
+++ b/urls.py
@@ -10,7 +10,12 @@
 #
 import os.path
 
-from django.conf.urls import patterns, url
+import django
+if django.VERSION < (1, 6):
+    from django.conf.urls.defaults import *
+else:
+    from django.conf.urls import *
+
 from django.views.static import serve
 
 from . import views

--- a/views.py
+++ b/views.py
@@ -34,6 +34,10 @@ from omero_searcher_config import omero_contentdb_path
 pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 import ricerca
 
+# Forwards/backwards compatibility with django 1.4/1.5/1.6
+# http://trac.openmicroscopy.org.uk/ome/ticket/11800
+import django.template
+django.template.add_to_builtins('django.templatetags.future')
 
 # Note some of these views can be called from either the standard OMERO.web
 # pages or from an OMERO.searcher page, since it is possible to iteratively

--- a/views.py
+++ b/views.py
@@ -34,10 +34,6 @@ from omero_searcher_config import omero_contentdb_path
 pyslid.database.direct.set_contentdb_path(omero_contentdb_path)
 import ricerca
 
-# Forwards/backwards compatibility with django 1.4/1.5/1.6
-# http://trac.openmicroscopy.org.uk/ome/ticket/11800
-import django.template
-django.template.add_to_builtins('django.templatetags.future')
 
 # Note some of these views can be called from either the standard OMERO.web
 # pages or from an OMERO.searcher page, since it is possible to iteratively


### PR DESCRIPTION
Urls need to be quoted in Django 1.6 (OMERO 5), some other stuff is needed to ensure this is backwards compatible with Django 1.3 (OMERO4.4). In addition there are a few other changes to make this work with 5.0.

Testing: OMERO.searcher should work on 4.4 and 5.0 installations.

Note the installation script has also been updated, see openmicroscopy/omero_searcher#19

On OMERO 4.4 it should be sufficient to run the installation script.

`./install.sh /path/to/OMERO_SERVER`

On OMERO 5.0:

`./install.sh /path/to/OMERO_SERVER --omero5`

If the configuration fails you may have to manually add the web-app:

```
omero config set omero.web.apps '["omero_searcher"]'
```

and for OMERO5 also configure the right hand pane:

```
"omero" config set omero.web.ui.right_plugins \
    '[["Acquisition", "webclient/data/includes/right_plugin.acquisition.js.html", "metadata_tab"],
["Preview", "webclient/data/includes/right_plugin.preview.js.html", "preview_tab"],
["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'
```
