### PR TITLE
Additional parameters for the installation script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,10 @@ is available from the EPEL repository:
 
     yum install freeimage
 
+On Debian it is available in the standard repositories:
+
+    apt-get install libfreeimage3
+
 On Mac OS X it can be installed using homebrew:
 
     brew install freeimage
@@ -30,6 +34,10 @@ For example, on CentOS:
 
     yum install python-imaging numpy scipy
 
+On Debian:
+
+    apt-get install python-imaging python-numpy python-scipy
+
 Alternatively install manually using pip:
 
     pip install PIL
@@ -38,7 +46,8 @@ Alternatively install manually using pip:
 
 Note OMERO.searcher requires OMERO.tables to be running. Although
 OMERO.tables is included in OMERO.server it is automatically disabled if
-Pytables is missing.
+Pytables is missing. See
+http://www.openmicroscopy.org/site/support/omero5/sysadmins/unix/server-installation.html
 
 
 Installation script

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,13 +57,9 @@ The installation script will install OMERO.searcher, retaining the previous
 configuration file if found. It will attempt to install several Python
 dependencies. See below for manual installation instructions.
 
-To install OMERO.searcher to a 4.4 server:
+To install OMERO.searcher:
 
     ./install.sh /path/to/OMERO_SERVER
-
-For a 5.0 server:
-
-    ./install.sh /path/to/OMERO_SERVER --omero5
 
 Run
 
@@ -72,7 +68,7 @@ Run
 for help on additional arguments.
 
 If you have previously installed a web application the OMERO.web
-configuration step will fail, see Configuration above for details how to
+configuration step will fail, see Configuration below for details on how to
 manually enable OMERO.searcher in OMERO.web.
 
 
@@ -98,7 +94,9 @@ Configuration
 
 After installing OMERO.searcher you must create a directory for storing
 the feature databases. Edit the settings in
-$OMERO_SERVER/lib/python/omeroweb/omero_searcher/omero_searcher_config.py
+
+    $OMERO_SERVER/lib/python/omeroweb/omero_searcher/omero_searcher_config.py
+
 and ensure the directory exists.
 
 In addition OMERO.web must be configured to use the OMERO.searcher web-app.
@@ -108,8 +106,7 @@ along the lines of
 
     omero config set omero.web.apps '[..., "omero_searcher"]'
 
-On OMERO 5 it is necessary to explicitly configure the right hand plugin
-pane
+You will also need to explicitly configure the right hand plugin pane:
 
     omero config set omero.ui.right_plugins \
         '[[...], ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,114 @@
+OMERO.searcher installation
+===========================
+
+The easiest way to install OMERO.searcher on a clean OMERO.server (not
+previously customised) is to check you have the required prerequisites,
+run the supplied installation script, and configure OMERO.searcher.
+
+
+Prerequisites
+-------------
+
+OMERO.searcher has several python dependencies. It is highly recommended
+that you first create and activate a Python virtualenv which must contain
+all the usual OMERO.server requirements.
+
+In addition OMERO.searcher indirectly (via one of its Python dependencies)
+requires the freeimage library to be installed in advance. On CentOS this
+is available from the EPEL repository:
+
+    yum install freeimage
+
+On Mac OS X it can be installed using homebrew:
+
+    brew install freeimage
+
+Python prerequisites include the PIL, numpy and scipy Python modules.
+Automatic installation of these modules sometimes fails, so it is
+recommended that you install a distribution supplied version if available.
+For example, on CentOS:
+
+    yum install python-imaging numpy scipy
+
+Alternatively install manually using pip:
+
+    pip install PIL
+    pip install numpy
+    pip install scipy
+
+Note OMERO.searcher requires OMERO.tables to be running. Although
+OMERO.tables is included in OMERO.server it is automatically disabled if
+Pytables is missing.
+
+
+Installation script
+-------------------
+
+The installation script will install OMERO.searcher, retaining the previous
+configuration file if found. It will attempt to install several Python
+dependencies. See below for manual installation instructions.
+
+To install OMERO.searcher to a 4.4 server:
+
+    ./install.sh /path/to/OMERO_SERVER
+
+For a 5.0 server:
+
+    ./install.sh /path/to/OMERO_SERVER --omero5
+
+Run
+
+    ./install.sh -h
+
+for help on additional arguments.
+
+If you have previously installed a web application the OMERO.web
+configuration step will fail, see Configuration above for details how to
+manually enable OMERO.searcher in OMERO.web.
+
+
+Manual installation
+-------------------
+
+Install Python dependencies by running
+
+    pip install -r requirements.txt
+
+Clone the OMERO.searcher repository into your OMERO.web directory
+
+    cd $OMERO_SERVER/lib/python/omeroweb
+    git clone https://github.com/openmicroscopy/omero_searcher.git
+
+Move the feature calculation scripts into the scripts directory
+
+    mv omero_searcher/scripts $OMERO_SERVER/lib/scripts/searcher
+
+
+Configuration
+-------------
+
+After installing OMERO.searcher you must create a directory for storing
+the feature databases. Edit the settings in
+$OMERO_SERVER/lib/python/omeroweb/omero_searcher/omero_searcher_config.py
+and ensure the directory exists.
+
+In addition OMERO.web must be configured to use the OMERO.searcher web-app.
+If the automated configuration step failed during installation, or if you
+wish to configure OMERO.searcher and OMERO.web manually, run something
+along the lines of
+
+    omero config set omero.web.apps '[..., "omero_searcher"]'
+
+On OMERO 5 it is necessary to explicitly configure the right hand plugin
+pane
+
+    omero config set omero.ui.right_plugins \
+        '[[...], ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'
+
+For further details see
+
+- http://www.openmicroscopy.org/site/support/omero5/developers/Web/CreateApp.html#add-your-app-to-omero-web
+- http://www.openmicroscopy.org/site/support/omero5/developers/Web/WebclientPlugin.html#plugin-installation
+
+You can now restart OMERO.web, remembering to first enter the virtualenv if
+necessary.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+OMERO.searcher
+==============
+
+OMERO.searcher provides content-based image search for
+[OMERO](http://openmicroscopy.org/).
+
+See [INSTALL.md](INSTALL.md) for prerequisites and installation instructions.

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,10 @@ set -e
 echo "OMERO.searcher installation script"
 
 usage() {
-    echo "USAGE: $(basename $0) OMERO_PREFIX [--nodeps] [--noconf] [--omero5]"
+    echo "USAGE: $(basename $0) OMERO_PREFIX [--nodeps] [--noconf]"
     echo "  OMERO_PREFIX: The root directory of the OMERO server installation"
     echo "  --nodeps: Don't install requirements"
     echo "  --noconf: Don't attempt to automatically configure any OMERO.web app settings"
-    echo "  --omero5: Attempt to automatically configure OMERO.searcher for OMERO5"
     exit $1
 }
 
@@ -25,7 +24,6 @@ check_py_mod() {
 
 NODEPS=0
 NOCONF=0
-OMERO_VERSION=4
 OMERO_SERVER=
 
 while [ $# -gt 0 ]; do
@@ -43,10 +41,6 @@ while [ $# -gt 0 ]; do
 
         "--noconf")
             NOCONF=1
-            ;;
-
-        "--omero5")
-            OMERO_VERSION=5
             ;;
 
         *)
@@ -136,13 +130,7 @@ else
         exit 2
     }
 
-    if [ $OMERO_VERSION -eq 4 -a -z "$CONFIG_KEY" ]; then
-        "$OMERO" config set omero.web.apps '["omero_searcher"]' || {
-            echo "ERROR: Failed to run $OMERO config"
-            exit 2
-        }
-
-    elif [ $OMERO_VERSION -eq 5 -a -z "$CONFIG_KEY" -a -z "$CONFIG_RIGHT" ];
+    if [ -z "$CONFIG_KEY" -a -z "$CONFIG_RIGHT" ];
     then
         "$OMERO" config set omero.web.apps '["omero_searcher"]' || {
             echo "ERROR: Failed to run $OMERO config"
@@ -164,9 +152,9 @@ else
 cat <<EOF
 
 ***** WARNING *****
-OMERO web-apps configuration failed.
+OMERO web-apps auto-configuration failed.
 The omero.web.apps or omero.web.ui.right_plugins configuration keys are
-non-empty. See INSTALL.md for help.
+non-empty. See INSTALL.md for help on manual configuration.
 EOF
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Abort on error
 set -e
@@ -37,13 +37,37 @@ normally automatically enabled if Pytables is installed, but if
 you see errors when running the OMERO.searcher feature calculation
 check that it is running.
 
+Configuration
+-------------
+
+After installing OMERO.searcher you must create a directory for storing
+the features databases. Edit the settings in
+$OMERO_SERVER/lib/python/omeroweb/omero_searcher/omero_searcher_config.py
+and ensure the directory exists.
+
+In addition OMERO.web must be configured to use the OMERO.searcher web-app.
+For instance, run something along the lines of
+    omero config set omero.web.apps '[..., "omero_searcher"]'
+
+On OMERO 5 it is necessary to explicitly configure the right hand plugin
+pane:
+    omero config set omero.ui.right_plugins \\
+        '[[...], ...
+          ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'
+
+See http://www.openmicroscopy.org/site/support/omero5/developers/Web/CreateApp.html#add-your-app-to-omero-web
+and http://www.openmicroscopy.org/site/support/omero5/developers/Web/WebclientPlugin.html#plugin-installation
+for further details
+---------------------------------------------------------------------------
 
 EOF
 
 usage() {
-    echo "USAGE: `basename $0` OMERO_PREFIX [--nodeps]"
+    echo "USAGE: `basename $0` OMERO_PREFIX [--nodeps] [--noconf] [--omero5]"
     echo "  OMERO_PREFIX: The root directory of the OMERO server installation"
     echo "  --nodeps: Don't install requirements"
+    echo "  --noconf: Don't attempt to automatically configure any OMERO.web app settings"
+    echo "  --omero5: Attempt to automatically configure OMERO.searcher for OMERO5"
     exit $1
 }
 
@@ -59,26 +83,52 @@ check_py_mod() {
     set -e
 }
 
-if [ $# -eq 0 -o "$1" = "-h" ]; then
-    usage 0
-fi
-
 NODEPS=0
-if [ $# -ne 1 ]; then
-    if [ $# -gt 2 -o "$2" != "--nodeps" ]; then
-        echo "Unexpected arguments"
-        usage 2
-    fi
-    NODEPS=1
+NOCONF=0
+OMERO_VERSION=4
+OMERO_SERVER=
+
+while [ $# -gt 0 ]; do
+    arg="$1"
+    shift
+
+    case "$arg" in
+        "-h")
+            usage 0
+            ;;
+
+        "--nodeps")
+            NODEPS=1
+            ;;
+
+        "--noconf")
+            NOCONF=1
+            ;;
+
+        "--omero5")
+            OMERO_VERSION=5
+            ;;
+
+        *)
+            if [ -n "$OMERO_SERVER" ]; then
+                echo "Unexpected arguments"
+                usage 1
+            fi
+            OMERO_SERVER="$arg"
+            ;;
+    esac
+done
+
+if [ -z "$OMERO_SERVER" ]; then
+    usage 1
 fi
 
-if [ ! -d "$1" ]; then
-    echo "Invalid server directory: $1"
+if [ ! -d "$OMERO_SERVER" ]; then
+    echo "Invalid server directory: $OMERO_SERVER"
     usage 2
 fi
 
 
-OMERO_SERVER="$1"
 SCRIPT_DEST="$OMERO_SERVER/lib/scripts/searcher"
 WEB_DEST="$OMERO_SERVER/lib/python/omeroweb/omero_searcher"
 CONFIG="$WEB_DEST/omero_searcher_config.py"
@@ -106,9 +156,13 @@ if [ -e "$CONFIG" ]; then
 fi
 
 if [ -e "$SCRIPT_DEST" -o -e "$WEB_DEST" ]; then
-    echo
-    echo "***** WARNING *****"
-    echo "Deleting $SCRIPT_DEST and/or $WEB_DEST in 5s, hit Ctrl-C to abort"
+cat <<EOF
+
+***** WARNING *****
+Deleting $SCRIPT_DEST
+and $WEB_DEST
+in 5s, hit Ctrl-C to abort
+EOF
     sleep 5
     rm -rf "$SCRIPT_DEST" "$WEB_DEST"
 fi
@@ -126,35 +180,64 @@ if [ -n "$OLD_CONFIG" ]; then
     mv "$OLD_CONFIG" "$CONFIG"
 fi
 
-echo "Configuring OMERO web-apps"
-OMERO="$OMERO_SERVER/bin/omero"
+if [ $NOCONF -eq 1 ]; then
+    echo "Skipping OMERO.searcher web configuration"
+else
+    echo "Configuring OMERO web-apps"
+    OMERO="$OMERO_SERVER/bin/omero"
 
-# Disable exit on failure so that we can print out a more informative message
-set +e
-CONFIG_KEY=`"$OMERO" config get omero.web.apps`
-if [ $? -ne 0 ]; then
-    echo "ERROR: Failed to run $OMERO config"
-    exit 2
-fi
-
-if [ -z "$CONFIG_KEY" ]; then
-    "$OMERO" config set omero.web.apps "[\"omero_searcher\"]"
+    # Disable exit on failure so that we can print out a more informative
+    # message
+    set +e
+    CONFIG_KEY=`"$OMERO" config get omero.web.apps`
     if [ $? -ne 0 ]; then
         echo "ERROR: Failed to run $OMERO config"
         exit 2
     fi
-else
-    # TODO: Automatically append omero_searcher to the omero.web.apps config key
-    # (requires parsing the existing value of omero.web.apps if any)
+
+    CONFIG_RIGHT=`"$OMERO" config get omero.web.ui.right_plugins`
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to run $OMERO config"
+        exit 2
+    fi
+
+    if [ $OMERO_VERSION -eq 4 -a -z "$CONFIG_KEY" ]; then
+        "$OMERO" config set omero.web.apps '["omero_searcher"]'
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Failed to run $OMERO config"
+            exit 2
+        fi
+
+    elif [ $OMERO_VERSION -eq 5 -a -z "$CONFIG_KEY" -a -z "$CONFIG_RIGHT" ];
+    then
+        "$OMERO" config set omero.web.apps '["omero_searcher"]'
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Failed to run $OMERO config"
+            exit 2
+        fi
+
+        TABacquisition='["Acquisition", "webclient/data/includes/right_plugin.acquisition.js.html", "metadata_tab"]'
+        TABpreview='["Preview", "webclient/data/includes/right_plugin.preview.js.html", "preview_tab"]'
+        TABsearcher='["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]'
+        "$OMERO" config set omero.web.ui.right_plugins \
+            "[$TABacquisition, $TABpreview, $TABsearcher]"
+        if [ $? -ne 0 ]; then
+            echo "ERROR: Failed to run $OMERO config"
+            exit 2
+        fi
+    else
+        # TODO: Automatically append omero_searcher to the omero.web.apps
+        # config key (requires parsing the existing value of omero.web.apps
+        # if any)
 cat <<EOF
 
 ***** WARNING *****
 OMERO web-apps configuration failed.
-The omero.web.apps configuration key is non-empty. Please enable
-OMERO.searcher manually by running something like:
-    omero config set omero.web.apps '[..., \"omero_searcher\"]'"
-
+The omero.web.apps or omero.web.ui.right_plugins configuration keys are
+non-empty. Please enable OMERO.searcher manually, for help run
+    $0 -h
 EOF
+    fi
 fi
 
 if [ -z "$OLD_CONFIG" ]; then

--- a/install.sh
+++ b/install.sh
@@ -3,64 +3,7 @@
 # Abort on error
 set -e
 
-cat <<EOF
-OMERO.searcher installation script
-==================================
-
-Installs OMERO.searcher, retains the previous configuration file if
-found.
-
-This script will attempt to install several Python dependencies. It
-is highly recommended that you first create and activate a Python
-virtualenv. This virtualenv must contain all the usual OMERO.server
-requirements.
-
-The Python mahotas module requires the freeimage library to be
-installed in advance. On CentOS this is available from the EPEL
-repository:
-    yum install freeimage
-On Mac OS X it can be installed using homebrew:
-    brew install freeimage
-
-Prerequisites include the PIL, numpy and scipy Python modules.
-Automatic installation of these modules sometimes fails, so it is
-normally easiest to install a distribution supplied version if
-available. For example on CentOS:
-    yum install python-imaging numpy scipy
-Alternatively install manually using pip:
-    pip install PIL
-    pip install numpy
-    pip install scipy
-
-OMERO.tables must be enabled and running on OMERO.server. It is
-normally automatically enabled if Pytables is installed, but if
-you see errors when running the OMERO.searcher feature calculation
-check that it is running.
-
-Configuration
--------------
-
-After installing OMERO.searcher you must create a directory for storing
-the features databases. Edit the settings in
-$OMERO_SERVER/lib/python/omeroweb/omero_searcher/omero_searcher_config.py
-and ensure the directory exists.
-
-In addition OMERO.web must be configured to use the OMERO.searcher web-app.
-For instance, run something along the lines of
-    omero config set omero.web.apps '[..., "omero_searcher"]'
-
-On OMERO 5 it is necessary to explicitly configure the right hand plugin
-pane:
-    omero config set omero.ui.right_plugins \\
-        '[[...], ...
-          ["Searcher", "searcher/plugin_config/right_search_form.js.html", "right_search_form"]]'
-
-See http://www.openmicroscopy.org/site/support/omero5/developers/Web/CreateApp.html#add-your-app-to-omero-web
-and http://www.openmicroscopy.org/site/support/omero5/developers/Web/WebclientPlugin.html#plugin-installation
-for further details
----------------------------------------------------------------------------
-
-EOF
+echo "OMERO.searcher installation script"
 
 usage() {
     echo "USAGE: `basename $0` OMERO_PREFIX [--nodeps] [--noconf] [--omero5]"
@@ -234,8 +177,7 @@ cat <<EOF
 ***** WARNING *****
 OMERO web-apps configuration failed.
 The omero.web.apps or omero.web.ui.right_plugins configuration keys are
-non-empty. Please enable OMERO.searcher manually, for help run
-    $0 -h
+non-empty. See INSTALL.md for help.
 EOF
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -41,8 +41,9 @@ check that it is running.
 EOF
 
 usage() {
-    echo "USAGE: `basename $0` OMERO_PREFIX"
+    echo "USAGE: `basename $0` OMERO_PREFIX [--nodeps]"
     echo "  OMERO_PREFIX: The root directory of the OMERO server installation"
+    echo "  --nodeps: Don't install requirements"
     exit $1
 }
 
@@ -62,9 +63,13 @@ if [ $# -eq 0 -o "$1" = "-h" ]; then
     usage 0
 fi
 
+NODEPS=0
 if [ $# -ne 1 ]; then
-    echo "Unexpected arguments"
-    usage 2
+    if [ $# -gt 2 -o "$2" != "--nodeps" ]; then
+        echo "Unexpected arguments"
+        usage 2
+    fi
+    NODEPS=1
 fi
 
 if [ ! -d "$1" ]; then
@@ -78,17 +83,21 @@ SCRIPT_DEST="$OMERO_SERVER/lib/scripts/searcher"
 WEB_DEST="$OMERO_SERVER/lib/python/omeroweb/omero_searcher"
 CONFIG="$WEB_DEST/omero_searcher_config.py"
 
-echo "Checking for PIL, numpy and scipy"
-check_py_mod PIL "ERROR: Please install PIL" 1
-check_py_mod numpy "ERROR: Please install numpy" 1
-check_py_mod scipy "ERROR: Please install scipy" 1
-check_py_mod tables \
+if [ $NODEPS -eq 1 ]; then
+    echo "Skipping dependencies"
+else
+    echo "Checking for PIL, numpy and scipy"
+    check_py_mod PIL "ERROR: Please install PIL" 1
+    check_py_mod numpy "ERROR: Please install numpy" 1
+    check_py_mod scipy "ERROR: Please install scipy" 1
+    check_py_mod tables \
 "WARNING: Pytables appears to be missing. If OMERO.tables is running
 on a different server this doesn't matter, otherwise please check
 OMERO.tables is running." 0
 
-echo "Installing python dependencies"
-pip install -r requirements.txt
+    echo "Installing python dependencies"
+    pip install -r requirements.txt
+fi
 
 if [ -e "$CONFIG" ]; then
     echo "Saving old configuration"


### PR DESCRIPTION
Add `--nodeps`, `--noconf` and `--omero5` options to install script so we can manually choose deps, or disable configuration, or configure for OMERO5 insteads of OMERO4.

Run `./install.sh -h` for help with parameters.

Also added README.md and INSTALL.md
