### PR TITLE
Add button to download the content DB

### DIFF
--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -356,9 +356,6 @@
 
     <form id="export_contentdb" class="content_search" method="POST"
         action="{% url 'exportcontentdb' %}">
-        <label for="doExportCdb">
-            Download the content DB
-        </label>
         <input name="featureset_Name" value="{{ fset }}" type="hidden" />
         <input style="float:right" id="doExportCdb" type="submit"
             value="Download content DB" />

--- a/templates/searcher/contentsearch/searchpage.html
+++ b/templates/searcher/contentsearch/searchpage.html
@@ -354,6 +354,16 @@
             value="Export results" />
     </form>
 
+    <form id="export_contentdb" class="content_search" method="POST"
+        action="{% url 'exportcontentdb' %}">
+        <label for="doExportCdb">
+            Download the content DB
+        </label>
+        <input name="featureset_Name" value="{{ fset }}" type="hidden" />
+        <input style="float:right" id="doExportCdb" type="submit"
+            value="Download content DB" />
+    </form>
+
     </div>
 
 </div>

--- a/urls.py
+++ b/urls.py
@@ -27,6 +27,7 @@ urlpatterns = patterns('django.views.generic.simple',
 
     url( r'^contentsearch/$', views.contentsearch, name="contentsearch"), 
     url( r'^exportsearch/$', views.exportsearch, name="exportsearch"),
+    url( r'^exportcontentdb/$', views.exportcontentdb, name="exportcontentdb"),
     url( r'^featureCalculationConfig/(?:(?P<object_type>[a-zA-Z0-9]+))/(?:(?P<object_ID>[0-9]+)/)?$', views.featureCalculationConfig, name="featureCalculationConfig"),  ## BK 
     url( r'^featureCalculation/(?:(?P<object_type>[a-zA-Z0-9]+))/(?:(?P<object_ID>[0-9]+))/(?:(?P<featureset>[a-zA-Z0-9]+))/(?:(?P<contentDB_config>[a-zA-Z0-9\-\,\.]+)/)?$', views.featureCalculation, name="featureCalculation"),  ## BK
 ##    url( r'^getSearchContentDBfromRemoteServer/?$', views.getSearchContentDBfromRemoteServer, name="getSearchContentDBfromRemoteServer"),  ## BK                       

--- a/views.py
+++ b/views.py
@@ -805,7 +805,7 @@ def exportcontentdb(request, conn=None, **kwargs):
 
     logger.debug('Exporting contentdb: %s', dbname)
 
-    response = HttpResponse(content_type='application/octet-stream')
+    response = HttpResponse(content_type='application/python-pickle')
     response['Content-Disposition'] = 'attachment; filename="%s"' % dbname
     pickle.dump(cdb, response)
     return response

--- a/views.py
+++ b/views.py
@@ -19,6 +19,9 @@ from operator import itemgetter
 from django.http import HttpResponse
 from django.template import loader, Context
 
+# For ContentDB export
+import pickle
+
 from omeroweb.webclient.decorators import login_required, render_response
 from webclient.webclient_gateway import OmeroWebGateway
 
@@ -777,6 +780,34 @@ def exportsearch(request, conn=None, **kwargs):
 
     logger.debug('Exporting search results: %s', images)
     response.write(t.render(c))
+    return response
+
+
+@login_required(setGroupContext=True)
+@render_response()
+def exportcontentdb(request, conn=None, **kwargs):
+    logger.debug('exportcontentdb POST:%s', request.POST)
+    ftset = request.POST.get('featureset_Name')
+
+    # Two separate calls, one to get the filename and one to get the contents
+    # TODO: Maybe modify pyslid to return a file handle instead of re-pickling
+    dbname, dbname_next, result = pyslid.database.direct.getRecentName(
+        conn, ftset)
+    cdb, s = pyslid.database.direct.retrieve(conn, ftset)
+
+    if s != 'Good':
+        context = {'template':
+                       'searcher/contentsearch/search_error.html'}
+        context['message'] = (
+            'The Content DB for feature-set %s could not be found. '
+            'Have you calculated any features?') % ftset
+        return context
+
+    logger.debug('Exporting contentdb: %s', dbname)
+
+    response = HttpResponse(content_type='application/octet-stream')
+    response['Content-Disposition'] = 'attachment; filename="%s"' % dbname
+    pickle.dump(cdb, response)
     return response
 
 


### PR DESCRIPTION
As requested by CMU, the ability to download the ContentDB. A button should be present in the left-hand pane after doing a search, which will download the ContentDB (a Python pickle file).
